### PR TITLE
Add Count, Image fields to Spec

### DIFF
--- a/pkg/habitat/apis/cr/v1/register.go
+++ b/pkg/habitat/apis/cr/v1/register.go
@@ -26,7 +26,7 @@ var (
 )
 
 // GroupName is the group name used in this package.
-const GroupName = "cr.habitat-operator.github.com"
+const GroupName = "habitat.sh"
 
 // SchemeGroupVersion is the group version used to register these objects.
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const ServiceGroupResourcePlural = "service-groups"
+const ServiceGroupResourcePlural = "servicegroups"
 
 type ServiceGroup struct {
 	metav1.TypeMeta   `json:,inline"`
@@ -28,7 +28,12 @@ type ServiceGroup struct {
 }
 
 type ServiceGroupSpec struct {
+	// Name is the Service Group name.
+	Name string
+	// Count is the amount of Services to start in this Service Group.
 	Count int
+	// Image is the Docker image of the Habitat Service.
+	Image string
 }
 
 type ServiceGroupStatus struct {


### PR DESCRIPTION
This PR adds the `Count` and `Image` fields to the spec, representing the amount of instances, and the docker image to run.

Additionally, it removes a hyphen from the pluralization of the ServiceGroup CR, used as part of the k8s group identifier. That's because official k8s groups don't have hyphens between words (e.g. `apiextensions`).

And finally, it changes the group name for the CR, to resemble the `k8s.io` format used by the official components.

Closes #9.