### PR TITLE
Turn the operator into a long-running process

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -55,13 +55,17 @@ func run() int {
 	}
 
 	// Create ServiceGroup CRD.
-	crd, err := habitatclient.CreateCRD(apiextensionsclientset)
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		logger.Log("error", err)
-		return 1
-	}
+	_, crdErr := habitatclient.CreateCRD(apiextensionsclientset)
+	if crdErr != nil {
+		if !apierrors.IsAlreadyExists(crdErr) {
+			logger.Log("error", crdErr)
+			return 1
+		}
 
-	logger.Log("info", "created ServiceGroup CRD")
+		logger.Log("info", "ServiceGroup CRD already exists, continuing")
+	} else {
+		logger.Log("info", "created ServiceGroup CRD")
+	}
 
 	client, scheme, err := habitatclient.NewClient(config)
 	if err != nil {

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -69,14 +69,14 @@ func run() int {
 		return 1
 	}
 
-	controller := habitatcontroller.HabitatController{
+	hc := habitatcontroller.HabitatController{
 		HabitatClient: client,
 		HabitatScheme: scheme,
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	go controller.Run(ctx)
+	go hc.Run(ctx)
 
 	habitatclient.WaitForServiceGroupInstanceProcessed(client, "sg1")
 	if err != nil {

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -84,12 +84,6 @@ func run() int {
 	defer cancelFunc()
 	go hc.Run(ctx)
 
-	habitatclient.WaitForServiceGroupInstanceProcessed(client, "sg1")
-	if err != nil {
-		logger.Log("error", err)
-		return 1
-	}
-
 	term := make(chan os.Signal)
 	// Relay these signals to the `term` channel.
 	signal.Notify(term, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -63,11 +63,6 @@ func run() int {
 
 	logger.Log("info", "created ServiceGroup CRD")
 
-	defer func() {
-		apiextensionsclientset.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(crd.Name, nil)
-		logger.Log("info", "deleted ServiceGroup CRD")
-	}()
-
 	client, scheme, err := habitatclient.NewClient(config)
 	if err != nil {
 		logger.Log("error", err)

--- a/pkg/habitat/client/cr.go
+++ b/pkg/habitat/client/cr.go
@@ -29,7 +29,11 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const serviceGroupCRDName = crv1.ServiceGroupResourcePlural + "." + crv1.GroupName
+const (
+	serviceGroupCRDName = crv1.ServiceGroupResourcePlural + "." + crv1.GroupName
+	pollInterval        = 500 * time.Millisecond
+	timeOut             = 10 * time.Second
+)
 
 // CreateCRD creates the ServiceGroup Custom Resource Definition.
 // It checks if creation has completed successfully, and deletes the CRD in case of error.
@@ -55,7 +59,7 @@ func CreateCRD(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.C
 	}
 
 	// wait for CRD being established.
-	err = wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+	err = wait.Poll(pollInterval, timeOut, func() (bool, error) {
 		crd, err = clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(serviceGroupCRDName, metav1.GetOptions{})
 
 		if err != nil {

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -43,7 +43,10 @@ func (hc *HabitatController) Run(ctx context.Context) error {
 		return err
 	}
 
+	// This channel is closed when the context is canceled or times out.
 	<-ctx.Done()
+
+	// Err() contains the error, if any.
 	return ctx.Err()
 }
 

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -34,10 +34,10 @@ type HabitatController struct {
 }
 
 // Run starts a Habitat resource controller
-func (c *HabitatController) Run(ctx context.Context) error {
+func (hc *HabitatController) Run(ctx context.Context) error {
 	fmt.Printf("Watching Service Group objects\n")
 
-	_, err := c.watchServiceGroups(ctx)
+	_, err := hc.watchServiceGroups(ctx)
 	if err != nil {
 		fmt.Printf("error: Failed to register watch for ServiceGroup resource: %v\n", err)
 		return err
@@ -47,9 +47,9 @@ func (c *HabitatController) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func (c *HabitatController) watchServiceGroups(ctx context.Context) (cache.Controller, error) {
+func (hc *HabitatController) watchServiceGroups(ctx context.Context) (cache.Controller, error) {
 	source := cache.NewListWatchFromClient(
-		c.HabitatClient,
+		hc.HabitatClient,
 		crv1.ServiceGroupResourcePlural,
 		apiv1.NamespaceAll,
 		fields.Everything())
@@ -67,9 +67,9 @@ func (c *HabitatController) watchServiceGroups(ctx context.Context) (cache.Contr
 
 		// Your custom resource event handlers.
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    c.onAdd,
-			UpdateFunc: c.onUpdate,
-			DeleteFunc: c.onDelete,
+			AddFunc:    hc.onAdd,
+			UpdateFunc: hc.onUpdate,
+			DeleteFunc: hc.onDelete,
 		})
 
 	go controller.Run(ctx.Done())
@@ -77,14 +77,14 @@ func (c *HabitatController) watchServiceGroups(ctx context.Context) (cache.Contr
 	return controller, nil
 }
 
-func (c *HabitatController) onAdd(obj interface{}) {
+func (hc *HabitatController) onAdd(obj interface{}) {
 	sg := obj.(*crv1.ServiceGroup)
 	fmt.Printf("[CONTROLLER] OnAdd: %s", sg.ObjectMeta.SelfLink)
 
 	// NEVER modify objects from the store. It's a read-only, local cache.
 	// You can use exampleScheme.Copy() to make a deep copy of original object and modify this copy
 	// Or create a copy manually for better performance
-	copyObj, err := c.HabitatScheme.Copy(sg)
+	copyObj, err := hc.HabitatScheme.Copy(sg)
 	if err != nil {
 		fmt.Printf("ERROR creating a deep copy of ServiceGroup object: %v\n", err)
 		return
@@ -96,7 +96,7 @@ func (c *HabitatController) onAdd(obj interface{}) {
 		Message: "Successfully processed by controller",
 	}
 
-	err = c.HabitatClient.Put().
+	err = hc.HabitatClient.Put().
 		Name(sg.ObjectMeta.Name).
 		Namespace(sg.ObjectMeta.Namespace).
 		Resource(crv1.ServiceGroupResourcePlural).
@@ -111,14 +111,14 @@ func (c *HabitatController) onAdd(obj interface{}) {
 	}
 }
 
-func (c *HabitatController) onUpdate(oldObj, newObj interface{}) {
+func (hc *HabitatController) onUpdate(oldObj, newObj interface{}) {
 	oldServiceGroup := oldObj.(*crv1.ServiceGroup)
 	newServiceGroup := newObj.(*crv1.ServiceGroup)
 	fmt.Printf("[CONTROLLER] OnUpdate oldObj: %s\n", oldServiceGroup.ObjectMeta.SelfLink)
 	fmt.Printf("[CONTROLLER] OnUpdate newObj: %s\n", newServiceGroup.ObjectMeta.SelfLink)
 }
 
-func (c *HabitatController) onDelete(obj interface{}) {
+func (hc *HabitatController) onDelete(obj interface{}) {
 	sg := obj.(*crv1.ServiceGroup)
 	fmt.Printf("[CONTROLLER] OnDelete %s\n", sg.ObjectMeta.SelfLink)
 }


### PR DESCRIPTION
After starting the goroutines that listen for events, the operator's main thread simply waits for cancellation in the form of `SIGTERM` or of a message on the go [`Context`](https://golang.org/pkg/context/)'s channel.