### PR TITLE
Add CRD and Object examples

### DIFF
--- a/examples/crd.yml
+++ b/examples/crd.yml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: servicegroups.habitat.sh
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: habitat.sh
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: servicegroups
+    # singular name to be used as an alias on the CLI and for display
+    singular: servicegroup
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: ServiceGroup
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - sg

--- a/examples/service_group.yml
+++ b/examples/service_group.yml
@@ -1,0 +1,8 @@
+apiVersion: habitat.sh/v1
+kind: ServiceGroup
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: example-service-group
+spec:
+  count: 1
+  image: tianon/true

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -29,9 +29,9 @@ type ServiceGroup struct {
 
 type ServiceGroupSpec struct {
 	// Count is the amount of Services to start in this Service Group.
-	Count int
+	Count int `json:"count"`
 	// Image is the Docker image of the Habitat Service.
-	Image string
+	Image string `json:"image"`
 }
 
 type ServiceGroupStatus struct {

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -28,8 +28,6 @@ type ServiceGroup struct {
 }
 
 type ServiceGroupSpec struct {
-	// Name is the Service Group name.
-	Name string
 	// Count is the amount of Services to start in this Service Group.
 	Count int
 	// Image is the Docker image of the Habitat Service.

--- a/pkg/habitat/client/cr.go
+++ b/pkg/habitat/client/cr.go
@@ -30,9 +30,11 @@ import (
 )
 
 const (
-	serviceGroupCRDName = crv1.ServiceGroupResourcePlural + "." + crv1.GroupName
-	pollInterval        = 500 * time.Millisecond
-	timeOut             = 10 * time.Second
+	serviceGroupCRDName           = crv1.ServiceGroupResourcePlural + "." + crv1.GroupName
+	serviceGroupResourceShortName = "sg"
+
+	pollInterval = 500 * time.Millisecond
+	timeOut      = 10 * time.Second
 )
 
 // CreateCRD creates the ServiceGroup Custom Resource Definition.
@@ -47,8 +49,9 @@ func CreateCRD(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.C
 			Version: crv1.SchemeGroupVersion.Version,
 			Scope:   apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural: crv1.ServiceGroupResourcePlural,
-				Kind:   reflect.TypeOf(crv1.ServiceGroup{}).Name(),
+				Plural:     crv1.ServiceGroupResourcePlural,
+				Kind:       reflect.TypeOf(crv1.ServiceGroup{}).Name(),
+				ShortNames: []string{serviceGroupResourceShortName},
 			},
 		},
 	}


### PR DESCRIPTION
Allows the user to create and delete both the CRD and the custom object.

Also, adds a short name for the CRD, which allows for `kubectl get sg`.

Additionally, by adding JSON tags to the spec fields, it explicitly defines how they should be serialized to JSON/YAML (i.e., lowercase).