### PR TITLE
Create Deployment in the onAdd handler

### DIFF
--- a/examples/service_group-leader.yml
+++ b/examples/service_group-leader.yml
@@ -1,0 +1,9 @@
+apiVersion: habitat.sh/v1
+kind: ServiceGroup
+metadata:
+  name: example-leader-follower-service-group
+spec:
+  topology: leader-follower
+  image: tianon/true
+  # count must be at least 3 for a standalone topology
+  count: 3

--- a/examples/service_group-standalone.yml
+++ b/examples/service_group-standalone.yml
@@ -1,8 +1,7 @@
 apiVersion: habitat.sh/v1
 kind: ServiceGroup
 metadata:
-  # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: example-service-group
+  name: example-standalone-service-group
 spec:
   topology: standalone
   image: tianon/true

--- a/examples/service_group.yml
+++ b/examples/service_group.yml
@@ -4,5 +4,6 @@ metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: example-service-group
 spec:
-  count: 1
+  topology: standalone
   image: tianon/true
+  count: 1

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -31,7 +31,8 @@ type ServiceGroupSpec struct {
 	// Count is the amount of Services to start in this Service Group.
 	Count int `json:"count"`
 	// Image is the Docker image of the Habitat Service.
-	Image string `json:"image"`
+	Image    string `json:"image"`
+	Topology `json:"topology"`
 }
 
 type ServiceGroupStatus struct {
@@ -41,9 +42,14 @@ type ServiceGroupStatus struct {
 
 type ServiceGroupState string
 
+type Topology string
+
 const (
 	ServiceGroupStateCreated   ServiceGroupState = "Created"
 	ServiceGroupStateProcessed ServiceGroupState = "Processed"
+
+	TopologyStandalone     Topology = "standalone"
+	TopologyLeaderFollower Topology = "leader-follower"
 )
 
 type ServiceGroupList struct {

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -21,9 +21,12 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/typed/apps/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
@@ -36,8 +39,9 @@ type HabitatController struct {
 }
 
 type Config struct {
-	Client *rest.RESTClient
-	Scheme *runtime.Scheme
+	HabitatClient    *rest.RESTClient
+	KubernetesClient *v1beta1.AppsV1beta1Client
+	Scheme           *runtime.Scheme
 }
 
 func New(config Config, logger log.Logger) HabitatController {
@@ -68,7 +72,7 @@ func (hc *HabitatController) Run(ctx context.Context) error {
 
 func (hc *HabitatController) watchCustomResources(ctx context.Context) (cache.Controller, error) {
 	source := cache.NewListWatchFromClient(
-		hc.config.Client,
+		hc.config.HabitatClient,
 		crv1.ServiceGroupResourcePlural,
 		apiv1.NamespaceAll,
 		fields.Everything())
@@ -114,34 +118,42 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 
 	level.Debug(hc.logger).Log("msg", "validated object")
 
-	// NEVER modify objects from the store. It's a read-only, local cache.
-	// You can use exampleScheme.Copy() to make a deep copy of original object and modify this copy
-	// Or create a copy manually for better performance
-	copyObj, err := hc.config.Scheme.Copy(sg)
+	// This value needs to be passed as a *int32, so we convert it, assign it to a
+	// variable and afterwards pass a pointer to it.
+	count := int32(sg.Spec.Count)
+
+	// Create a deployment.
+	deployment := &appsv1beta1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-deployment", sg.Name),
+		},
+		Spec: appsv1beta1.DeploymentSpec{
+			Replicas: &count,
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"habitat": "true",
+					},
+				},
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name:  "habitat-service",
+							Image: sg.Spec.Image,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := hc.config.KubernetesClient.Deployments(apiv1.NamespaceDefault).Create(deployment)
 	if err != nil {
-		level.Error(hc.logger).Log("msg", "creating a deep copy of ServiceGroup object", "err", err)
+		level.Error(hc.logger).Log("msg", err)
 		return
 	}
 
-	sgCopy := copyObj.(*crv1.ServiceGroup)
-	sgCopy.Status = crv1.ServiceGroupStatus{
-		State:   crv1.ServiceGroupStateProcessed,
-		Message: "Successfully processed by controller",
-	}
-
-	err = hc.config.Client.Put().
-		Name(sg.ObjectMeta.Name).
-		Namespace(sg.ObjectMeta.Namespace).
-		Resource(crv1.ServiceGroupResourcePlural).
-		Body(sgCopy).
-		Do().
-		Error()
-
-	if err != nil {
-		level.Error(hc.logger).Log("msg", "updating status", "err", err)
-	} else {
-		level.Info(hc.logger).Log("function", "onAdd", "msg", "UPDATED status", "object", sgCopy)
-	}
+	level.Info(hc.logger).Log("msg", "created deployment", "name", result.GetObjectMeta().GetName())
 }
 
 func (hc *HabitatController) onUpdate(oldObj, newObj interface{}) {

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -101,6 +101,19 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 	sg := obj.(*crv1.ServiceGroup)
 	level.Debug(hc.logger).Log("function", "onAdd", "msg", sg.ObjectMeta.SelfLink)
 
+	// Validate object.
+	if err := validateCustomObject(*sg); err != nil {
+		if vErr, ok := err.(validationError); ok {
+			level.Error(hc.logger).Log("type", "validation error", "msg", err, "key", vErr.Key)
+			return
+		}
+
+		level.Error(hc.logger).Log("msg", err)
+		return
+	}
+
+	level.Debug(hc.logger).Log("msg", "validated object")
+
 	// NEVER modify objects from the store. It's a read-only, local cache.
 	// You can use exampleScheme.Copy() to make a deep copy of original object and modify this copy
 	// Or create a copy manually for better performance

--- a/pkg/habitat/controller/utils.go
+++ b/pkg/habitat/controller/utils.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	crv1 "github.com/kinvolk/habitat-operator/pkg/habitat/apis/cr/v1"
+)
+
+const leaderFollowerTopologyMinCount = 3
+
+type validationError struct {
+	msg string
+	// The key in the spec that contains an error.
+	Key string
+}
+
+func (err validationError) Error() string {
+	return err.msg
+}
+
+func validateCustomObject(sg crv1.ServiceGroup) error {
+	spec := sg.Spec
+
+	switch spec.Topology {
+	case crv1.TopologyStandalone:
+	case crv1.TopologyLeaderFollower:
+		if spec.Count < leaderFollowerTopologyMinCount {
+			return validationError{msg: "too few instances", Key: "count"}
+		}
+	default:
+	}
+
+	return nil
+}


### PR DESCRIPTION
We create a Deployment with label `habitat=true` in the default namespace. The image and count are taken from the CO.

We introduce the `Topology` field to the spec, matching those supported in habitat.

Basic validation is performed on the CO, to ensure that a leader-follower Service Group has at least 3 services.

Closes #10.