### PR TITLE
Implement onDelete handler

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -177,7 +177,7 @@ func (hc *HabitatController) onDelete(obj interface{}) {
 	level.Debug(hc.logger).Log("function", "onDelete", "msg", sg.ObjectMeta.SelfLink)
 
 	deploymentsClient := hc.config.KubernetesClient.Deployments(sg.ObjectMeta.Namespace)
-	deploymentName := fmt.Sprintf("%s-deployment", sg.Name)
+	deploymentName := sg.Name
 	deletePolicy := metav1.DeletePropagationForeground
 	deleteOptions := &metav1.DeleteOptions{
 		PropagationPolicy: &deletePolicy,

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -176,7 +176,7 @@ func (hc *HabitatController) onDelete(obj interface{}) {
 
 	level.Debug(hc.logger).Log("function", "onDelete", "msg", sg.ObjectMeta.SelfLink)
 
-	deploymentsClient := hc.config.KubernetesClient.Deployments(apiv1.NamespaceDefault)
+	deploymentsClient := hc.config.KubernetesClient.Deployments(sg.ObjectMeta.Namespace)
 	deploymentName := fmt.Sprintf("%s-deployment", sg.Name)
 	deletePolicy := metav1.DeletePropagationForeground
 	deleteOptions := &metav1.DeleteOptions{


### PR DESCRIPTION
It deletes the deployment created in the `onAdd`.

Also, we add checks around the type conversions of the events we receive from the `Informer`.