### PR TITLE
Fix deployment name suffix not being removed in onAdd

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -130,7 +130,7 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 	// Create a deployment.
 	deployment := &appsv1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-deployment", sg.Name),
+			Name: sg.Name,
 		},
 		Spec: appsv1beta1.DeploymentSpec{
 			Replicas: &count,


### PR DESCRIPTION
The suffix hardcoding has been removed from the onDelete, but was still
there in the onAdd.