### PR TITLE
Use consul + nginx services as docker images in examples

### DIFF
--- a/examples/service_group-leader.yml
+++ b/examples/service_group-leader.yml
@@ -4,6 +4,7 @@ metadata:
   name: example-leader-follower-service-group
 spec:
   topology: leader-follower
-  image: tianon/true
+  # the core/consul habitat service packaged as a Docker image
+  image: kinvolk/consul-hab
   # count must be at least 3 for a standalone topology
   count: 3

--- a/examples/service_group-standalone.yml
+++ b/examples/service_group-standalone.yml
@@ -4,5 +4,6 @@ metadata:
   name: example-standalone-service-group
 spec:
   topology: standalone
-  image: tianon/true
+  # the core/nginx habitat service packaged as a Docker image
+  image: kinvolk/nginx-hab
   count: 1


### PR DESCRIPTION
These images have been produced by running:

    hab pkg export docker core/nginx
    hab pkg export docker core/consul

This allows users to test whether both a standalone and a distributed application work out of the box.