### PR TITLE
Create ConfigMap with peer IP file

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -86,11 +86,16 @@ func run() int {
 	}
 
 	controllerConfig := habitatcontroller.Config{
-		HabitatClient:    habitatClient,
-		KubernetesClient: clientset.AppsV1beta1Client,
-		Scheme:           scheme,
+		AppsV1beta1Client: clientset.AppsV1beta1Client,
+		CoreV1Client:      clientset.CoreV1Client,
+		HabitatClient:     habitatClient,
+		Scheme:            scheme,
 	}
-	hc := habitatcontroller.New(controllerConfig, log.With(logger, "component", "controller"))
+	hc, err := habitatcontroller.New(controllerConfig, log.With(logger, "component", "controller"))
+	if err != nil {
+		level.Error(logger).Log("msg", err)
+		return 1
+	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -86,10 +86,9 @@ func run() int {
 	}
 
 	controllerConfig := habitatcontroller.Config{
-		AppsV1beta1Client: clientset.AppsV1beta1Client,
-		CoreV1Client:      clientset.CoreV1Client,
-		HabitatClient:     habitatClient,
-		Scheme:            scheme,
+		HabitatClient:       habitatClient,
+		KubernetesClientset: clientset,
+		Scheme:              scheme,
 	}
 	hc, err := habitatcontroller.New(controllerConfig, log.With(logger, "component", "controller"))
 	if err != nil {

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -223,12 +223,10 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 		},
 	}
 
-	{
-		_, err := hc.config.KubernetesClientset.CoreV1Client.ConfigMaps(apiv1.NamespaceDefault).Create(configMap)
-		if err != nil {
-			level.Error(hc.logger).Log("msg", err)
-			return
-		}
+	_, err = hc.config.KubernetesClientset.CoreV1Client.ConfigMaps(apiv1.NamespaceDefault).Create(configMap)
+	if err != nil {
+		level.Error(hc.logger).Log("msg", err)
+		return
 	}
 
 	level.Debug(hc.logger).Log("msg", "created ConfigMap with peer IP", "object", configMap.Data["peer-ip"])

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/typed/apps/v1beta1"
+	"k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
@@ -39,18 +41,35 @@ type HabitatController struct {
 }
 
 type Config struct {
-	HabitatClient    *rest.RESTClient
-	KubernetesClient *v1beta1.AppsV1beta1Client
-	Scheme           *runtime.Scheme
+	AppsV1beta1Client *v1beta1.AppsV1beta1Client
+	CoreV1Client      *v1.CoreV1Client
+	HabitatClient     *rest.RESTClient
+	Scheme            *runtime.Scheme
 }
 
-func New(config Config, logger log.Logger) HabitatController {
-	hc := HabitatController{
+func New(config Config, logger log.Logger) (*HabitatController, error) {
+	if config.AppsV1beta1Client == nil {
+		return nil, errors.New("invalid controller config: no AppsV1beta1Client")
+	}
+	if config.CoreV1Client == nil {
+		return nil, errors.New("invalid controller config: no CoreV1Client")
+	}
+	if config.HabitatClient == nil {
+		return nil, errors.New("invalid controller config: no HabitatClient")
+	}
+	if config.Scheme == nil {
+		return nil, errors.New("invalid controller config: no Schema")
+	}
+	if logger == nil {
+		return nil, errors.New("invalid controller config: no logger")
+	}
+
+	hc := &HabitatController{
 		config: config,
 		logger: logger,
 	}
 
-	return hc
+	return hc, nil
 }
 
 // Run starts a Habitat resource controller
@@ -123,11 +142,12 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 
 	level.Debug(hc.logger).Log("msg", "validated object")
 
+	// Create a deployment.
+
 	// This value needs to be passed as a *int32, so we convert it, assign it to a
 	// variable and afterwards pass a pointer to it.
 	count := int32(sg.Spec.Count)
 
-	// Create a deployment.
 	deployment := &appsv1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: sg.Name,
@@ -145,6 +165,32 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 						{
 							Name:  "habitat-service",
 							Image: sg.Spec.Image,
+							VolumeMounts: []apiv1.VolumeMount{
+								{
+									Name:      "config",
+									MountPath: "/kubernetes-configmap",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					// Define the volume for the ConfigMap.
+					Volumes: []apiv1.Volume{
+						{
+							Name: "config",
+							VolumeSource: apiv1.VolumeSource{
+								ConfigMap: &apiv1.ConfigMapVolumeSource{
+									LocalObjectReference: apiv1.LocalObjectReference{
+										Name: configMapName(sg),
+									},
+									Items: []apiv1.KeyToPath{
+										{
+											Key:  "peer-watch-file",
+											Path: "peer-watch-file",
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -152,13 +198,45 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 		},
 	}
 
-	result, err := hc.config.KubernetesClient.Deployments(apiv1.NamespaceDefault).Create(deployment)
+	d, err := hc.config.AppsV1beta1Client.Deployments(apiv1.NamespaceDefault).Create(deployment)
 	if err != nil {
 		level.Error(hc.logger).Log("msg", err)
 		return
 	}
 
-	level.Info(hc.logger).Log("msg", "created deployment", "name", result.GetObjectMeta().GetName())
+	level.Info(hc.logger).Log("msg", "created deployment", "name", d.GetObjectMeta().GetName())
+
+	// Create the ConfigMap for the peer watch file.
+	configMap := &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: configMapName(sg),
+			// Declare this ConfigMap to be owned by the Deployment, so that deleting
+			// the Deployment deletes the ConfigMap.
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "extensions/v1beta1",
+					Kind:       "Deployment",
+					Name:       sg.Name,
+					UID:        d.UID,
+				},
+			},
+		},
+		// Initially, the file will be empty. It will be populated by the
+		// controller once the first pod has gotten an IP assigned to it.
+		Data: map[string]string{
+			"peer-watch-file": "",
+		},
+	}
+
+	{
+		_, err := hc.config.CoreV1Client.ConfigMaps(apiv1.NamespaceDefault).Create(configMap)
+		if err != nil {
+			level.Error(hc.logger).Log("msg", err)
+			return
+		}
+	}
+
+	level.Debug(hc.logger).Log("msg", "created ConfigMap with peer IP", "object", configMap.Data["peer-ip"])
 }
 
 func (hc *HabitatController) onUpdate(oldObj, newObj interface{}) {
@@ -176,9 +254,12 @@ func (hc *HabitatController) onDelete(obj interface{}) {
 
 	level.Debug(hc.logger).Log("function", "onDelete", "msg", sg.ObjectMeta.SelfLink)
 
-	deploymentsClient := hc.config.KubernetesClient.Deployments(sg.ObjectMeta.Namespace)
+	deploymentsClient := hc.config.AppsV1beta1Client.Deployments(sg.ObjectMeta.Namespace)
 	deploymentName := sg.Name
-	deletePolicy := metav1.DeletePropagationForeground
+
+	// With this policy, dependent resources will be deleted, but we don't wait
+	// for that to happen.
+	deletePolicy := metav1.DeletePropagationBackground
 	deleteOptions := &metav1.DeleteOptions{
 		PropagationPolicy: &deletePolicy,
 	}
@@ -190,4 +271,8 @@ func (hc *HabitatController) onDelete(obj interface{}) {
 	}
 
 	level.Info(hc.logger).Log("msg", "deleted deployment", "name", deploymentName)
+}
+
+func configMapName(sg *crv1.ServiceGroup) string {
+	return fmt.Sprintf("%s-peer-file", sg.Name)
 }

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -168,7 +168,7 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 							VolumeMounts: []apiv1.VolumeMount{
 								{
 									Name:      "config",
-									MountPath: "/kubernetes-configmap",
+									MountPath: "/habitat-operator",
 									ReadOnly:  true,
 								},
 							},
@@ -186,7 +186,7 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 									Items: []apiv1.KeyToPath{
 										{
 											Key:  "peer-watch-file",
-											Path: "peer-watch-file",
+											Path: "peer-ip",
 										},
 									},
 								},

--- a/pkg/habitat/controller/utils.go
+++ b/pkg/habitat/controller/utils.go
@@ -40,6 +40,7 @@ func validateCustomObject(sg crv1.ServiceGroup) error {
 			return validationError{msg: "too few instances", Key: "count"}
 		}
 	default:
+		return validationError{msg: "unknown topology", Key: "topology"}
 	}
 
 	return nil


### PR DESCRIPTION
This creates a ConfigMap, links it to the Deployment (so that deleting the Deployment deletes the CM), and mounts a file in the containers under `/kuberntes-configmap/peer-watch-file`.

The weird path is because the mount point must be reasonably unique, otherwise it will hide resources already present in the container's filesystem.

For now, the file is empty. It will be populated as part of #11.

The file(system) is mounted as readonly. In case we decide to allow supervisors to change it due to gossip events, we can mark it as read-write later on.

Closes #21.