### PR TITLE
Add support for --group flag

### DIFF
--- a/examples/service_group-leader.yml
+++ b/examples/service_group-leader.yml
@@ -3,8 +3,11 @@ kind: ServiceGroup
 metadata:
   name: example-leader-follower-service-group
 spec:
-  topology: leader-follower
   # the core/consul habitat service packaged as a Docker image
   image: kinvolk/consul-hab
   # count must be at least 3 for a standalone topology
   count: 3
+  habitat:
+    topology: leader-follower
+    # if not present, defaults to "default"
+    group: foobar

--- a/examples/service_group-standalone.yml
+++ b/examples/service_group-standalone.yml
@@ -3,7 +3,10 @@ kind: ServiceGroup
 metadata:
   name: example-standalone-service-group
 spec:
-  topology: standalone
   # the core/nginx habitat service packaged as a Docker image
   image: kinvolk/nginx-hab
   count: 1
+  habitat:
+    topology: standalone
+    # if not present, defaults to "default"
+    group: foobar

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -29,11 +29,10 @@ type ServiceGroup struct {
 
 type ServiceGroupSpec struct {
 	// Count is the amount of Services to start in this Service Group.
-	Count int    `json:"count"`
-	Group string `json:"group"`
+	Count int `json:"count"`
 	// Image is the Docker image of the Habitat Service.
-	Image    string `json:"image"`
-	Topology `json:"topology"`
+	Image   string  `json:"image"`
+	Habitat Habitat `json:"habitat"`
 }
 
 type ServiceGroupStatus struct {
@@ -42,6 +41,14 @@ type ServiceGroupStatus struct {
 }
 
 type ServiceGroupState string
+
+type Habitat struct {
+	// Group is the value of the --group flag for the hab client.
+	// Optional. Defaults to `default`.
+	Group string `json:"group"`
+	// Topology is the value of the --topology flag for the hab client.
+	Topology `json:"topology"`
+}
 
 type Topology string
 

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -29,7 +29,8 @@ type ServiceGroup struct {
 
 type ServiceGroupSpec struct {
 	// Count is the amount of Services to start in this Service Group.
-	Count int `json:"count"`
+	Count int    `json:"count"`
+	Group string `json:"group"`
 	// Image is the Docker image of the Habitat Service.
 	Image    string `json:"image"`
 	Topology `json:"topology"`

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -138,8 +138,8 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 	level.Debug(hc.logger).Log("msg", "validated object")
 
 	group := "default"
-	if sg.Spec.Group != "" {
-		group = sg.Spec.Group
+	if sg.Spec.Habitat.Group != "" {
+		group = sg.Spec.Habitat.Group
 	}
 
 	// This value needs to be passed as a *int32, so we convert it, assign it to a

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -137,12 +137,16 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 
 	level.Debug(hc.logger).Log("msg", "validated object")
 
-	// Create a deployment.
+	group := "default"
+	if sg.Spec.Group != "" {
+		group = sg.Spec.Group
+	}
 
 	// This value needs to be passed as a *int32, so we convert it, assign it to a
 	// variable and afterwards pass a pointer to it.
 	count := int32(sg.Spec.Count)
 
+	// Create a deployment.
 	deployment := &appsv1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: sg.Name,
@@ -160,6 +164,9 @@ func (hc *HabitatController) onAdd(obj interface{}) {
 						{
 							Name:  "habitat-service",
 							Image: sg.Spec.Image,
+							Args: []string{
+								"--group", group,
+							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{
 									Name:      "config",

--- a/pkg/habitat/controller/utils.go
+++ b/pkg/habitat/controller/utils.go
@@ -33,7 +33,7 @@ func (err validationError) Error() string {
 func validateCustomObject(sg crv1.ServiceGroup) error {
 	spec := sg.Spec
 
-	switch spec.Topology {
+	switch spec.Habitat.Topology {
 	case crv1.TopologyStandalone:
 	case crv1.TopologyLeaderFollower:
 		if spec.Count < leaderFollowerTopologyMinCount {


### PR DESCRIPTION
The value of the `group` key in the CRD is passed to the command line flag `--group`.

If none is specified, we use the value "default", which is the same as
not specifying any --group.

Passing arguments like this works because the images have `init.sh` as their [`ENTRYPOINT`](https://github.com/habitat-sh/habitat/blob/a66961df540e0ced8acf8d94d0b6e9aa79d322b8/components/pkg-dockerize/bin/hab-pkg-dockerize.sh#L139).

`init.sh` simply [runs](https://github.com/habitat-sh/habitat/blob/a66961df540e0ced8acf8d94d0b6e9aa79d322b8/components/studio/libexec/hab-studio-type-baseimage.sh#L122)`hab sup start core/nginx --group default`

Closes #23.