### PR TITLE
Rename CRD from ServiceGroup to HabitatService

### DIFF
--- a/examples/crd.yml
+++ b/examples/crd.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: servicegroups.habitat.sh
+  name: habitatservices.habitat.sh
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: habitat.sh
@@ -12,11 +12,11 @@ spec:
   scope: Namespaced
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>
-    plural: servicegroups
+    plural: habitatservices
     # singular name to be used as an alias on the CLI and for display
-    singular: servicegroup
+    singular: habitatservice
     # kind is normally the CamelCased singular type. Your resource manifests use this.
-    kind: ServiceGroup
+    kind: HabitatService
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
-    - sg
+    - hs

--- a/examples/habitat_service-leader.yml
+++ b/examples/habitat_service-leader.yml
@@ -1,7 +1,7 @@
 apiVersion: habitat.sh/v1
-kind: ServiceGroup
+kind: HabitatService
 metadata:
-  name: example-leader-follower-service-group
+  name: example-leader-follower-habitat-service
 spec:
   topology: leader-follower
   # the core/consul habitat service packaged as a Docker image

--- a/examples/habitat_service-standalone.yml
+++ b/examples/habitat_service-standalone.yml
@@ -1,7 +1,7 @@
 apiVersion: habitat.sh/v1
-kind: ServiceGroup
+kind: HabitatService
 metadata:
-  name: example-standalone-service-group
+  name: example-standalone-habitat-service
 spec:
   topology: standalone
   # the core/nginx habitat service packaged as a Docker image

--- a/pkg/habitat/apis/cr/v1/register.go
+++ b/pkg/habitat/apis/cr/v1/register.go
@@ -39,8 +39,8 @@ func Resource(resource string) schema.GroupResource {
 // addKnownTypes adds the set of types defined in this package to the supplied scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
-		&ServiceGroup{},
-		&ServiceGroupList{},
+		&HabitatService{},
+		&HabitatServiceList{},
 	)
 
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -18,16 +18,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const ServiceGroupResourcePlural = "servicegroups"
+const HabitatServiceResourcePlural = "habitatservices"
 
-type ServiceGroup struct {
+type HabitatService struct {
 	metav1.TypeMeta   `json:,inline"`
 	metav1.ObjectMeta `json:"metadata"`
-	Spec              ServiceGroupSpec   `json:"spec"`
-	Status            ServiceGroupStatus `json:"status,omitempty"`
+	Spec              HabitatServiceSpec   `json:"spec"`
+	Status            HabitatServiceStatus `json:"status,omitempty"`
 }
 
-type ServiceGroupSpec struct {
+type HabitatServiceSpec struct {
 	// Count is the amount of Services to start in this Service Group.
 	Count int `json:"count"`
 	// Image is the Docker image of the Habitat Service.
@@ -35,25 +35,25 @@ type ServiceGroupSpec struct {
 	Topology `json:"topology"`
 }
 
-type ServiceGroupStatus struct {
-	State   ServiceGroupState `json:"state,omitempty"`
-	Message string            `json:"message,omitempty"`
+type HabitatServiceStatus struct {
+	State   HabitatServiceState `json:"state,omitempty"`
+	Message string              `json:"message,omitempty"`
 }
 
-type ServiceGroupState string
+type HabitatServiceState string
 
 type Topology string
 
 const (
-	ServiceGroupStateCreated   ServiceGroupState = "Created"
-	ServiceGroupStateProcessed ServiceGroupState = "Processed"
+	HabitatServiceStateCreated   HabitatServiceState = "Created"
+	HabitatServiceStateProcessed HabitatServiceState = "Processed"
 
 	TopologyStandalone     Topology = "standalone"
 	TopologyLeaderFollower Topology = "leader-follower"
 )
 
-type ServiceGroupList struct {
+type HabitatServiceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
-	Items           []ServiceGroup `json:"items"`
+	Items           []HabitatService `json:"items"`
 }

--- a/pkg/habitat/apis/cr/v1/types_test.go
+++ b/pkg/habitat/apis/cr/v1/types_test.go
@@ -26,17 +26,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
-var _ runtime.Object = &ServiceGroup{}
-var _ metav1.ObjectMetaAccessor = &ServiceGroup{}
+var _ runtime.Object = &HabitatService{}
+var _ metav1.ObjectMetaAccessor = &HabitatService{}
 
-var _ runtime.Object = &ServiceGroupList{}
-var _ metav1.ListMetaAccessor = &ServiceGroupList{}
+var _ runtime.Object = &HabitatServiceList{}
+var _ metav1.ListMetaAccessor = &HabitatServiceList{}
 
-func serviceGroupFuzzerFuncs(t apitesting.TestingCommon) []interface{} {
+func HabitatServiceFuzzerFuncs(t apitesting.TestingCommon) []interface{} {
 	return []interface{}{
-		func(obj *ServiceGroupList, c fuzz.Continue) {
+		func(obj *HabitatServiceList, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)
-			obj.Items = make([]ServiceGroup, c.Intn(10))
+			obj.Items = make([]HabitatService, c.Intn(10))
 			for i := range obj.Items {
 				c.Fuzz(&obj.Items[i])
 			}
@@ -53,9 +53,9 @@ func TestRoundTrip(t *testing.T) {
 	AddToScheme(scheme)
 
 	seed := rand.Int63()
-	fuzzerFuncs := apitesting.MergeFuzzerFuncs(t, apitesting.GenericFuzzerFuncs(t, codecs), serviceGroupFuzzerFuncs(t))
+	fuzzerFuncs := apitesting.MergeFuzzerFuncs(t, apitesting.GenericFuzzerFuncs(t, codecs), HabitatServiceFuzzerFuncs(t))
 	fuzzer := apitesting.FuzzerFor(fuzzerFuncs, rand.NewSource(seed))
 
-	apitesting.RoundTripSpecificKindWithoutProtobuf(t, SchemeGroupVersion.WithKind("ServiceGroup"), scheme, codecs, fuzzer, nil)
-	apitesting.RoundTripSpecificKindWithoutProtobuf(t, SchemeGroupVersion.WithKind("ServiceGroupList"), scheme, codecs, fuzzer, nil)
+	apitesting.RoundTripSpecificKindWithoutProtobuf(t, SchemeGroupVersion.WithKind("HabitatService"), scheme, codecs, fuzzer, nil)
+	apitesting.RoundTripSpecificKindWithoutProtobuf(t, SchemeGroupVersion.WithKind("HabitatServiceList"), scheme, codecs, fuzzer, nil)
 }

--- a/pkg/habitat/client/cr.go
+++ b/pkg/habitat/client/cr.go
@@ -29,28 +29,28 @@ import (
 )
 
 const (
-	serviceGroupCRDName           = crv1.ServiceGroupResourcePlural + "." + crv1.GroupName
-	serviceGroupResourceShortName = "sg"
+	HabitatServiceCRDName           = crv1.HabitatServiceResourcePlural + "." + crv1.GroupName
+	HabitatServiceResourceShortName = "hs"
 
 	pollInterval = 500 * time.Millisecond
 	timeOut      = 10 * time.Second
 )
 
-// CreateCRD creates the ServiceGroup Custom Resource Definition.
+// CreateCRD creates the HabitatService Custom Resource Definition.
 // It checks if creation has completed successfully, and deletes the CRD in case of error.
 func CreateCRD(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: serviceGroupCRDName,
+			Name: HabitatServiceCRDName,
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   crv1.GroupName,
 			Version: crv1.SchemeGroupVersion.Version,
 			Scope:   apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:     crv1.ServiceGroupResourcePlural,
-				Kind:       reflect.TypeOf(crv1.ServiceGroup{}).Name(),
-				ShortNames: []string{serviceGroupResourceShortName},
+				Plural:     crv1.HabitatServiceResourcePlural,
+				Kind:       reflect.TypeOf(crv1.HabitatService{}).Name(),
+				ShortNames: []string{HabitatServiceResourceShortName},
 			},
 		},
 	}
@@ -62,7 +62,7 @@ func CreateCRD(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.C
 
 	// wait for CRD being established.
 	err = wait.Poll(pollInterval, timeOut, func() (bool, error) {
-		crd, err = clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(serviceGroupCRDName, metav1.GetOptions{})
+		crd, err = clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(HabitatServiceCRDName, metav1.GetOptions{})
 
 		if err != nil {
 			return false, err
@@ -87,7 +87,7 @@ func CreateCRD(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.C
 
 	// delete CRD if there was an error.
 	if err != nil {
-		deleteErr := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(serviceGroupCRDName, nil)
+		deleteErr := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(HabitatServiceCRDName, nil)
 		if deleteErr != nil {
 			return nil, errors.NewAggregate([]error{err, deleteErr})
 		}
@@ -98,17 +98,17 @@ func CreateCRD(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.C
 	return crd, nil
 }
 
-// WaitForServiceGroupInstanceProcessed polls the API for a specific ServiceGroup with a state of "Processed".
-func WaitForServiceGroupInstanceProcessed(client *rest.RESTClient, name string) error {
+// WaitForHabitatServiceInstanceProcessed polls the API for a specific HabitatService with a state of "Processed".
+func WaitForHabitatServiceInstanceProcessed(client *rest.RESTClient, name string) error {
 	return wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
-		var sg crv1.ServiceGroup
+		var hs crv1.HabitatService
 		err := client.Get().
-			Resource(crv1.ServiceGroupResourcePlural).
+			Resource(crv1.HabitatServiceResourcePlural).
 			Namespace(apiv1.NamespaceDefault).
 			Name(name).
-			Do().Into(&sg)
+			Do().Into(&hs)
 
-		if err == nil && sg.Status.State == crv1.ServiceGroupStateProcessed {
+		if err == nil && hs.Status.State == crv1.HabitatServiceStateProcessed {
 			return true, nil
 		}
 

--- a/pkg/habitat/controller/utils.go
+++ b/pkg/habitat/controller/utils.go
@@ -30,8 +30,8 @@ func (err validationError) Error() string {
 	return err.msg
 }
 
-func validateCustomObject(sg crv1.ServiceGroup) error {
-	spec := sg.Spec
+func validateCustomObject(hs crv1.HabitatService) error {
+	spec := hs.Spec
 
 	switch spec.Topology {
 	case crv1.TopologyStandalone:


### PR DESCRIPTION
This is to avoid ambiguity between the ServiceGroup CRD, and the service
group concept in Habitat, selected with the `--group` flag in the CLI.

See https://github.com/kinvolk/habitat-operator/pull/29