### PR TITLE
add simple nodejs app to examples

### DIFF
--- a/examples/nodejs/nodejs-service.yml
+++ b/examples/nodejs/nodejs-service.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-nodejs-service-group
+spec:
+  selector:
+    service-group: example-nodejs-service-group
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: 30001
+    port: 5555
+    protocol: TCP
+  - name: http-gateway
+    nodePort : 32767
+    port: 9631
+    protocol: TCP

--- a/examples/nodejs/service_group-nodejs.yml
+++ b/examples/nodejs/service_group-nodejs.yml
@@ -1,0 +1,10 @@
+apiVersion: habitat.sh/v1
+kind: ServiceGroup
+metadata:
+  name: example-nodejs-service-group
+spec:
+  image: kinvolk/nodejs-hab
+  count: 1
+  habitat:
+    topology: standalone
+    group: nodejs


### PR DESCRIPTION
This adds a simple Node.js application following the habitat getting started guides. This is added to showcase how port exposing can be done using [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/).

We expose the ports in the `nodejs-service.yml` file, for both Node.js application and the Habitat HTTP Gateway to be accessible.

Our Node.js app is on port 30001. We expose the HTTP Gateway on port 32767 in this example.