### PR TITLE
Badge and other small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![travis] ![report]
+[![Build Status](https://travis-ci.org/kinvolk/habitat-operator.svg?branch=master)](https://travis-ci.org/kinvolk/habitat-operator) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/kinvolk/habitat-operator)](https://goreportcard.com/report/github.com/kinvolk/habitat-operator)
 
 # habitat-operator
 
@@ -33,6 +34,4 @@ If you add, remove or change an import, run:
 
     dep ensure
 
-[travis]: https://travis-ci.org/kinvolk/habitat-operator.svg?branch=master
-[report]: https://goreportcard.com/badge/github.com/kinvolk/habitat-operator
 [crd]: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -21,7 +21,7 @@ import (
 const ServiceGroupResourcePlural = "servicegroups"
 
 type ServiceGroup struct {
-	metav1.TypeMeta   `json:,inline"`
+	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 	Spec              ServiceGroupSpec   `json:"spec"`
 	Status            ServiceGroupStatus `json:"status,omitempty"`

--- a/pkg/habitat/client/client.go
+++ b/pkg/habitat/client/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// client wraps the `rest` package's client.
+// Package client wraps the `rest` package's client.
 package client
 
 import (


### PR DESCRIPTION
Badges were not linking to Travis and Go report card, but rather to the images.

Also included are some issues from [Go report card](https://goreportcard.com/report/github.com/kinvolk/habitat-operator).