### PR TITLE
Use only ServiceGroup name as ConfigMap name

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -408,5 +408,5 @@ func newConfigMap(sgName string, parentUID types.UID, ip string) *apiv1.ConfigMa
 }
 
 func configMapName(sgName string) string {
-	return fmt.Sprintf("%s-peer-file", sgName)
+	return sgName
 }


### PR DESCRIPTION
We don't need to use more than one ConfigMap, since we can just add keys
to an existing one.

Therefore, it makes sense to use the SG name as CM name.