### PR TITLE
Simplify Leader IP handling

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -285,12 +285,15 @@ func (hc *HabitatController) onPodUpdate(oldObj, newObj interface{}) {
 	// TODO: Do not retrieve or write IP if we are deploying a standalone topology.
 	pod, ok := newObj.(*apiv1.Pod)
 	if !ok {
-		level.Error(hc.logger).Log("msg", "Failed to cast pod.")
+		level.Error(hc.logger).Log("msg", "Unknown event received in Pod Update handler")
 		return
 	}
+
 	if pod == nil {
+		level.Warn(hc.logger).Log("msg", "Empty event received in Pod Update handler")
 		return
 	}
+
 	if pod.Status.Phase != apiv1.PodRunning {
 		return
 	}
@@ -304,37 +307,47 @@ func (hc *HabitatController) onPodUpdate(oldObj, newObj interface{}) {
 func (hc *HabitatController) onPodDelete(obj interface{}) {
 	pod, ok := obj.(*apiv1.Pod)
 	if !ok {
-		level.Error(hc.logger).Log("msg", "Failed to cast pod.")
+		level.Error(hc.logger).Log("msg", "Unknown event received in Pod Delete handler")
 		return
 	}
+
 	if pod == nil {
+		level.Warn(hc.logger).Log("msg", "Empty event received in Pod Delete handler")
 		return
 	}
+
 	sgName, exists := pod.ObjectMeta.Labels["service-group"]
 	if !exists {
-		level.Error(hc.logger).Log("msg", "Could not retrieve service group name because label did not exist.")
+		level.Error(hc.logger).Log("msg", "Could not retrieve service group name because label does not exist.")
 		return
 	}
+
 	cmName := configMapName(sgName)
+
 	cm, err := hc.config.KubernetesClientset.CoreV1().ConfigMaps(apiv1.NamespaceDefault).Get(cmName, metav1.GetOptions{})
 	if err != nil {
 		level.Error(hc.logger).Log("msg", err)
 		return
 	}
+
 	currIP := cm.Data[peerFile]
+
 	deletedPodIP := pod.Status.PodIP
 	if currIP != deletedPodIP {
 		return
 	}
-	// Get only those pods that are running.
+
+	// Get only running pods.
 	fs := fields.SelectorFromSet(fields.Set{
 		"status.phase": "Running",
 	})
+
 	podList, err := hc.config.KubernetesClientset.CoreV1().Pods(apiv1.NamespaceDefault).List(metav1.ListOptions{FieldSelector: fs.String()})
 	if err != nil {
 		level.Error(hc.logger).Log("msg", err)
 		return
 	}
+
 	for _, newPod := range podList.Items {
 		if newPod.Status.Phase == apiv1.PodRunning {
 			// Replace our IP in the CM file with a new IP of a running pod.

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -349,14 +349,12 @@ func (hc *HabitatController) onPodDelete(obj interface{}) {
 	}
 
 	for _, newPod := range podList.Items {
-		if newPod.Status.Phase == apiv1.PodRunning {
-			// Replace our IP in the CM file with a new IP of a running pod.
-			err := hc.writeLeaderIP(&newPod)
-			if err != nil {
-				level.Error(hc.logger).Log("msg", err)
-			}
-			return
+		// Replace our IP in the CM file with a new IP of a running pod.
+		if err := hc.writeLeaderIP(&newPod); err != nil {
+			level.Error(hc.logger).Log("msg", err)
 		}
+
+		return
 	}
 }
 


### PR DESCRIPTION
This PR simplifies the way we deal with the Leader IP file.

We can find out if the current leader is running using field selectors. This way, we only need to check if the length of the returned list of Pods is > 0, to know whether we need to do anything.

The PR also removes additional checks for the Pod status that are unnecessary since we already use fields to filter.