### PR TITLE
Check dependencies are present in Pod handler

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -318,7 +318,7 @@ func (hc *HabitatController) onPodDelete(obj interface{}) {
 	cmName := configMapName(sgName)
 	cm, err := hc.config.KubernetesClientset.CoreV1().ConfigMaps(apiv1.NamespaceDefault).Get(cmName, metav1.GetOptions{})
 	if err != nil {
-		level.Error(hc.logger).Log("msg", err)
+		level.Debug(hc.logger).Log("msg", "Pod event received, but ConfigMap already deleted")
 		return
 	}
 	currIP := cm.Data[peerFile]
@@ -352,6 +352,13 @@ func (hc *HabitatController) writeIP(pod *apiv1.Pod) error {
 	cmName := configMapName(sgName)
 	ip := pod.Status.PodIP
 
+	// We need to retrieve our deployment to get the UID for the OwnerReference.
+	d, err := hc.config.KubernetesClientset.AppsV1beta1Client.Deployments(apiv1.NamespaceDefault).Get(sgName, metav1.GetOptions{})
+	if err != nil {
+		level.Debug(hc.logger).Log("msg", "Pod event received, but Deployment already deleted")
+		return nil
+	}
+
 	cm, err := hc.config.KubernetesClientset.CoreV1().ConfigMaps(apiv1.NamespaceDefault).Get(cmName, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -372,12 +379,6 @@ func (hc *HabitatController) writeIP(pod *apiv1.Pod) error {
 				return nil
 			}
 		}
-	}
-
-	// We need to retrieve our deployment to get the UID for the OwnerReference.
-	d, err := hc.config.KubernetesClientset.AppsV1beta1Client.Deployments(apiv1.NamespaceDefault).Get(sgName, metav1.GetOptions{})
-	if err != nil {
-		return err
 	}
 
 	updatedCM := newConfigMap(sgName, d.UID, ip)


### PR DESCRIPTION
If either the Deployment or the ConfigMap are not present, the Pod
handler should exit early.

This happens because of the different rate at which resources are
deleted. If a SG is deleted, the Deployment and the ConfigMap are as
well.

But the Pod might take a little longer to be deleted, and in the
meantime, events for it will still be fired.

The handler should therefore check whether the resources it needs are
present, and if they aren't, it should simply exit.

Closes #51.