### PR TITLE
Log error when Deployment can't be created due to missing Secret

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -231,9 +231,6 @@ func (hc *HabitatController) onPodUpdate(oldObj, newObj interface{}) {
 		level.Error(hc.logger).Log("msg", "Failed to cast pod.")
 		return
 	}
-	if pod == nil {
-		return
-	}
 	if pod.Status.Phase != apiv1.PodRunning {
 		return
 	}
@@ -248,9 +245,6 @@ func (hc *HabitatController) onPodDelete(obj interface{}) {
 	pod, ok := obj.(*apiv1.Pod)
 	if !ok {
 		level.Error(hc.logger).Log("msg", "Failed to cast pod.")
-		return
-	}
-	if pod == nil {
 		return
 	}
 	sgName, exists := pod.ObjectMeta.Labels["service-group"]
@@ -406,17 +400,11 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 			return nil, err
 		}
 
-		if secret == nil {
-			// If we can't find the secret we should just return the base deployment.
-			level.Warn(hc.logger).Log("msg", "Secret could not be mounted as it did not exist.")
-			return nil, err
-		}
-
 		secretVolume := &apiv1.Volume{
 			Name: "initialconfig",
 			VolumeSource: apiv1.VolumeSource{
 				Secret: &apiv1.SecretVolumeSource{
-					SecretName: sg.Spec.Habitat.Config,
+					SecretName: secret.Name,
 					Items: []apiv1.KeyToPath{
 						{
 							Key:  userTomlFile,

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -396,7 +396,6 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 		// Let's make sure our secret is there before mounting it.
 		secret, err := hc.config.KubernetesClientset.CoreV1().Secrets(apiv1.NamespaceDefault).Get(sg.Spec.Habitat.Config, metav1.GetOptions{})
 		if err != nil {
-			level.Error(hc.logger).Log("msg", "Could not find Secret containing service configuration", "name", sg.Spec.Habitat.Config)
 			return nil, err
 		}
 

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -396,7 +396,7 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 		// Let's make sure our secret is there before mounting it.
 		secret, err := hc.config.KubernetesClientset.CoreV1().Secrets(apiv1.NamespaceDefault).Get(sg.Spec.Habitat.Config, metav1.GetOptions{})
 		if err != nil {
-			level.Error(hc.logger).Log("msg", "Could not find Secret containing service configuration")
+			level.Error(hc.logger).Log("msg", "Could not find Secret containing service configuration", "name", sg.Spec.Habitat.Config)
 			return nil, err
 		}
 

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -402,6 +402,7 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 		// Let's make sure our secret is there before mounting it.
 		secret, err := hc.config.KubernetesClientset.CoreV1().Secrets(apiv1.NamespaceDefault).Get(sg.Spec.Habitat.Config, metav1.GetOptions{})
 		if err != nil {
+			level.Error(hc.logger).Log("msg", "Could not find Secret containing service configuration")
 			return nil, err
 		}
 


### PR DESCRIPTION
It's an error so we should use `Error`.

Also, I think we don't need to check the resource for `== nil`, as I don't think Kubernetes would deliver us a `nil` struct if there wasn't an `error`.