### PR TITLE
Add make target for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ go:
 git:
   depth: 1
 
-script:  go test -v $(go list ./... | grep -v /vendor/)
+script:  make test

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,7 @@ linux:
 image: linux
 	docker build -t "$(IMAGE):$(TAG)" .
 
-.PHONY: build linux image
+test:
+	go test -v $(shell go list ./... | grep -v /vendor/)
+
+.PHONY: build test linux image

--- a/README.md
+++ b/README.md
@@ -50,4 +50,10 @@ If you add, remove or change an import, run:
 
     dep ensure
 
+### Testing
+
+To run unit tests, run:
+
+    make test
+
 [crd]: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/


### PR DESCRIPTION
I think `test` as a target makes sense now, and when we will merge E2E tests can rename this to `unit` and use `test` for both.