### PR TITLE
Implement workqueue

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -214,12 +214,12 @@
 [[projects]]
   branch = "master"
   name = "k8s.io/client-go"
-  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/apps/v1beta1","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/api/v1/ref","pkg/version","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","transport","util/cert","util/flowcontrol","util/homedir","util/integer"]
+  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/apps/v1beta1","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/api/v1/ref","pkg/version","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","transport","util/cert","util/flowcontrol","util/homedir","util/integer","util/workqueue"]
   revision = "a37549263b657d84535eb42492625846f1e8a7a5"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "63111ccd15f7f5b1631ebdfd662a2113979f3b46db96d777d2d83dbdb637a591"
+  inputs-digest = "4ed41eb4a7e231b51bc9470e976384ff1c44b50c8ce7a0919d6f126fbfcc5535"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -18,7 +18,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const ServiceGroupResourcePlural = "servicegroups"
+const (
+	ServiceGroupResourcePlural = "servicegroups"
+	ServiceGroupLabel          = "service-group"
+)
 
 type ServiceGroup struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/habitat/controller/utils.go
+++ b/pkg/habitat/controller/utils.go
@@ -15,6 +15,8 @@
 package controller
 
 import (
+	"fmt"
+
 	crv1 "github.com/kinvolk/habitat-operator/pkg/habitat/apis/cr/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -25,14 +27,12 @@ import (
 
 const leaderFollowerTopologyMinCount = 3
 
-type validationError struct {
-	msg string
-	// The key in the spec that contains an error.
-	Key string
+type serviceGroupNotFoundError struct {
+	key string
 }
 
-func (err validationError) Error() string {
-	return err.msg
+func (err serviceGroupNotFoundError) Error() string {
+	return fmt.Sprintf("could not find ServiceGroup with key %s", err.key)
 }
 
 func validateCustomObject(sg crv1.ServiceGroup) error {
@@ -42,10 +42,10 @@ func validateCustomObject(sg crv1.ServiceGroup) error {
 	case crv1.TopologyStandalone:
 	case crv1.TopologyLeaderFollower:
 		if spec.Count < leaderFollowerTopologyMinCount {
-			return validationError{msg: "too few instances", Key: "count"}
+			return fmt.Errorf("too few instances: %s", spec.Count)
 		}
 	default:
-		return validationError{msg: "unknown topology", Key: "topology"}
+		return fmt.Errorf("unkown topology: %s", spec.Habitat.Topology)
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds a ServiceGroup workqueue.

Following the guidelines, all event handlers (SG and Pod for now) do is retrieve the appropriate SG key and add a job to the queue.

The worker then consumes these jobs, and performs the necessary operations.

Closes #26, #51 and obsoletes #56.