### PR TITLE
Add support for custom ring key

### DIFF
--- a/examples/encrypted/README.md
+++ b/examples/encrypted/README.md
@@ -12,7 +12,14 @@ for platform-specific instructions on base64 encoding).
 The encoded key can then be used as the value of the `ring-key` key in a Kubernetes
 secret.
 
-The secret's name must be referenced in the `ServiceGroup` object's `ringKey`
+The secret's name should be the same as the filename of the key, minus the
+extension.
+
+For example, for a key named `foobar`, the key file might be something like
+`foobar-20170824094632.sym.key`, and the secret name should be
+`foobar-20170824094632`.
+
+The secret's name must additionally be referenced in the `ServiceGroup` object's `ringKey`
 key.
 
 ## Deletion

--- a/examples/encrypted/README.md
+++ b/examples/encrypted/README.md
@@ -1,0 +1,21 @@
+# Encrypted ServiceGroup example
+
+## Workflow
+
+The user needs to generate a key using `hab ring key generate foobar`, and then base64
+encode it (on Linux) with `hab ring export foobar | base64 -w 0` (please refer to
+[this
+document](https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-manually)
+for platform-specific instructions on base64 encoding).
+
+The encoded key can then be used as the value of the `ring-key` key in a Kubernetes
+secret.
+
+The secret's name must be referenced in the `ServiceGroup` object's `ringKey`
+key.
+
+## Deletion
+
+The operator does not delete the Secret on ServiceGroup deletion. This is
+because the user might want to re-use the secret across multiple
+`ServiceGroup`s and `ServiceGroup` lifecycles.

--- a/examples/encrypted/README.md
+++ b/examples/encrypted/README.md
@@ -2,7 +2,8 @@
 
 ## Workflow
 
-The user needs to generate a key using `hab ring key generate foobar`, and then base64
+The user needs to generate a [ring
+key](https://www.habitat.sh/docs/run-packages-security/) using `hab ring key generate foobar`, and then base64
 encode it (on Linux) with `hab ring export foobar | base64 -w 0` (please refer to
 [this
 document](https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-manually)

--- a/examples/encrypted/service_group.yml
+++ b/examples/encrypted/service_group.yml
@@ -8,7 +8,7 @@ metadata:
 type: Opaque
 data:
   # base64-encoded ring key
-  ring-key: U1lNLVNFQy0xCnJpbmcta2V5LTIwMTcwODE2MTAyMDQ5CgpyTmtKbkJxZHppVWdmdnYweEVhaWpzMWxHUGZUdHBLdFg0L0xaMmpQcWdJPQ==
+  ring-key: U1lNLVNFQy0xCnJpbmcta2V5LTIwMTcwODE2MTAyMDQ5CgpyTmtKbkJxZHppVWdmdnYweEVhaWpzMWxHUGZUdHBLdFg0L0xaMmpQcWdJPQo=
 ---
 apiVersion: habitat.sh/v1
 kind: ServiceGroup

--- a/examples/encrypted/service_group.yml
+++ b/examples/encrypted/service_group.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: example-encrypted-service-group-ring-key
+  name: ring-key-20170816102049
 type: Opaque
 data:
   # base64-encoded ring key
@@ -18,4 +18,4 @@ spec:
   habitat:
     topology: leader-follower
     # the name of the secret containing the ring key
-    ringKey: example-encrypted-service-group-ring-key
+    ringKey: ring-key-20170816102049

--- a/examples/encrypted/service_group.yml
+++ b/examples/encrypted/service_group.yml
@@ -13,9 +13,9 @@ metadata:
   name: example-encrypted-service-group
 spec:
   # the core/nginx habitat service packaged as a Docker image
-  image: kinvolk/nginx-hab
-  count: 1
+  image: kinvolk/consul-hab
+  count: 3
   habitat:
-    topology: standalone
+    topology: leader-follower
     # the name of the secret containing the ring key
     ringKey: example-encrypted-service-group-ring-key

--- a/examples/encrypted/service_group.yml
+++ b/examples/encrypted/service_group.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-encrypted-service-group-ring-key
+type: Opaque
+data:
+  # base64-encoded ring key
+  ring-key: U1lNLVNFQy0xCnJpbmcta2V5LTIwMTcwODE2MTAyMDQ5CgpyTmtKbkJxZHppVWdmdnYweEVhaWpzMWxHUGZUdHBLdFg0L0xaMmpQcWdJPQ==
+---
+apiVersion: habitat.sh/v1
+kind: ServiceGroup
+metadata:
+  name: example-encrypted-service-group
+spec:
+  # the core/nginx habitat service packaged as a Docker image
+  image: kinvolk/nginx-hab
+  count: 1
+  habitat:
+    topology: standalone
+    # the name of the secret containing the ring key
+    ringKey: example-encrypted-service-group-ring-key

--- a/examples/encrypted/service_group.yml
+++ b/examples/encrypted/service_group.yml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ring-key-20170816102049
+  labels:
+    habitat: "true"
+    ring-key: "true"
 type: Opaque
 data:
   # base64-encoded ring key

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -55,6 +55,9 @@ type Habitat struct {
 	// The file with this name is mounted inside of the pod. Habitat will
 	// use it for initial configuration of the service.
 	Config string `json:"config"`
+	// The name of the secret that contains the ring key.
+	// Optional.
+	RingKey string `json:"ringKey,omitempty"`
 }
 
 type Topology string

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -521,16 +521,8 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 			return nil, err
 		}
 
-		// The current time. We need this because ring keys must have a revision.
-		// This means that the timestamp in the filename and the one in the ring
-		// key itself will be different, because the one in the key reflects the
-		// current time at the moment the key was generated.
-		// This shouldn't be a problem though, since the timestamp in the key is
-		// not used.
-		ts := time.Now().Format("20060102150405")
-
 		// The filename under which the ring key is saved.
-		ringKeyFile := fmt.Sprintf("%s-%s.%s", ringName, ts, ringKeyFileExt)
+		ringKeyFile := fmt.Sprintf("%s.%s", ringName, ringKeyFileExt)
 
 		v := &apiv1.Volume{
 			Name: ringName,

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -511,6 +511,7 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 		base.Spec.Template.Spec.Volumes = append(base.Spec.Template.Spec.Volumes, *secretVolume)
 	}
 
+	// Handle ring key, if one is specified.
 	if sg.Spec.Habitat.RingKey != "" {
 		s, err := hc.config.KubernetesClientset.CoreV1().Secrets(apiv1.NamespaceDefault).Get(sg.Spec.Habitat.RingKey, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
This PR adds support for specifying a custom ring key, generated by the user and then inserted into a Kubernetes secret.

Closes #41.