### PR TITLE
Use namespace from resource instead of default

### DIFF
--- a/examples/namespaced/README.md
+++ b/examples/namespaced/README.md
@@ -1,0 +1,8 @@
+# Namespaced ServiceGroup example
+
+## Workflow
+
+Simply run `kubectl create -f examples/namespaced/service_group.yml`.
+
+Note that any Secrets used by a ServiceGroup must be in the same namespace as
+the ServiceGroup itself.

--- a/examples/namespaced/service_group.yml
+++ b/examples/namespaced/service_group.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-namespace
+---
+apiVersion: habitat.sh/v1
+kind: ServiceGroup
+metadata:
+  name: example-standalone-service-group
+  namespace: example-namespace
+spec:
+  # the core/nginx habitat service packaged as a Docker image
+  image: kinvolk/nginx-hab
+  count: 1
+  habitat:
+    topology: standalone
+    # if not present, defaults to "default"
+    group: foobar
+

--- a/examples/namespaced/service_group.yml
+++ b/examples/namespaced/service_group.yml
@@ -16,4 +16,3 @@ spec:
     topology: standalone
     # if not present, defaults to "default"
     group: foobar
-

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -472,7 +472,7 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 	// If we have a secret name present we should mount that secret.
 	if sg.Spec.Habitat.Config != "" {
 		// Let's make sure our secret is there before mounting it.
-		secret, err := hc.config.KubernetesClientset.CoreV1().Secrets(apiv1.NamespaceDefault).Get(sg.Spec.Habitat.Config, metav1.GetOptions{})
+		secret, err := hc.config.KubernetesClientset.CoreV1().Secrets(sg.Namespace).Get(sg.Spec.Habitat.Config, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -169,7 +169,7 @@ func (hc *HabitatController) handleServiceGroupCreation(sg *crv1.ServiceGroup) e
 	// Create Deployment, if it doesn't already exist.
 	var d *appsv1beta1.Deployment
 
-	d, err = hc.config.KubernetesClientset.AppsV1beta1Client.Deployments(apiv1.NamespaceDefault).Create(deployment)
+	d, err = hc.config.KubernetesClientset.AppsV1beta1Client.Deployments(sg.Namespace).Create(deployment)
 	if err != nil {
 		// Was the error due to the Deployment already existing?
 		if !apierrors.IsAlreadyExists(err) {
@@ -259,7 +259,7 @@ func (hc *HabitatController) handleConfigMap(sg *crv1.ServiceGroup, deploymentUI
 
 	newCM := newConfigMap(sg.Name, deploymentUID, leaderIP)
 
-	cm, err := hc.config.KubernetesClientset.CoreV1Client.ConfigMaps(apiv1.NamespaceDefault).Create(newCM)
+	cm, err := hc.config.KubernetesClientset.CoreV1Client.ConfigMaps(sg.Namespace).Create(newCM)
 	if err != nil {
 		// Was the error due to the ConfigMap already existing?
 		if !apierrors.IsAlreadyExists(err) {


### PR DESCRIPTION
This allows us to support custom namespaces for ServiceGroups and all
resources handled by the operator.

I'm not even sure we need an example, as that's more part of how K8s works. WDYT?

Closes #50.