### PR TITLE
Use spf13/pflag package for CLI flags

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -220,6 +220,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4ed41eb4a7e231b51bc9470e976384ff1c44b50c8ce7a0919d6f126fbfcc5535"
+  inputs-digest = "531d75a0e07ebd3fc03717072114ae6fb6c36348444d52e2f721739b11f87585"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -16,13 +16,13 @@ package main
 
 import (
 	"context"
-	"flag"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	flag "github.com/spf13/pflag"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"


### PR DESCRIPTION
The glog package [injects](https://github.com/golang/glog/blob/23def4e6c14b4da8ac2ed8007337bc5eb5007998/glog.go#L398-L404) its own flags into any package that imports it and that uses the `flag` library from the standard library.

By using [another library](https://github.com/spf13/pflag), we ignore glog's flags and are able to only display our own.

There might be other, better libraries for this, but I opted for this since it's a drop-in for the `flag` package. 

Closes #62.