### PR TITLE
Fix error where cm variable would be nil

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -244,6 +244,11 @@ func (hc *HabitatController) handleConfigMap(sg *crv1.ServiceGroup, deploymentUI
 
 			// Delete the IP in the existing ConfigMap, as it must necessarily be invalid,
 			// since there are no running Pods.
+			cm, err = hc.config.KubernetesClientset.CoreV1Client.ConfigMaps(sg.Namespace).Get(newCM.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
 			if err := hc.writeLeaderIP(cm, ""); err != nil {
 				return err
 			}


### PR DESCRIPTION
In the error handling block, the `cm` variable had value `nil`, and
therefore passing it to the `writeLeaderIP` method was an error.

This bug presented itself in situations where the operator would start and the ConfigMap already existed. The operator would try to [access a key in the `nil` ConfigMap](https://github.com/kinvolk/habitat-operator/blob/04cf8859bfe440d9eb971509569b3682cba1a1f5/pkg/habitat/controller/controller.go#L219), and it would crash.