### PR TITLE
Handle leader-follower topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 
 The Habitat Operator makes use of [`Custom Resource Definition`][crd]s, and requires a Kubernetes cluster of version `>= 1.7.0`.
 
+At the moment, the Operator requires a forked version of the Habitat supervisor
+that adds support for the `--peer-watch-file` flag.
+See [this issue](https://github.com/habitat-sh/habitat/issues/2735) to track
+progress on upstreaming the feature.
+
+This means that images need to be created using the aforementioned fork of the
+`hab` client, which can be accomplished using [this
+script](https://gist.github.com/krnowak/3c854e94245e2f33a8366e629bfb09c8).
+
 ## Installing
 
     go get -u github.com/kinvolk/habitat-operator/cmd/operator

--- a/examples/leader/service_group.yml
+++ b/examples/leader/service_group.yml
@@ -8,6 +8,6 @@ spec:
   # count must be at least 3 for a leader-follower topology
   count: 3
   habitat:
-    topology: leader-follower
+    topology: leader
     # if not present, defaults to "default"
     group: foobar

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -66,8 +66,8 @@ const (
 	ServiceGroupStateCreated   ServiceGroupState = "Created"
 	ServiceGroupStateProcessed ServiceGroupState = "Processed"
 
-	TopologyStandalone     Topology = "standalone"
-	TopologyLeaderFollower Topology = "leader-follower"
+	TopologyStandalone Topology = "standalone"
+	TopologyLeader     Topology = "leader"
 )
 
 type ServiceGroupList struct {

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -62,6 +62,10 @@ type Habitat struct {
 
 type Topology string
 
+func (t Topology) String() string {
+	return string(t)
+}
+
 const (
 	ServiceGroupStateCreated   ServiceGroupState = "Created"
 	ServiceGroupStateProcessed ServiceGroupState = "Processed"

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -21,6 +21,10 @@ import (
 const (
 	ServiceGroupResourcePlural = "servicegroups"
 	ServiceGroupLabel          = "service-group"
+
+	TopologyLabel = "topology"
+
+	HabitatLabel = "habitat"
 )
 
 type ServiceGroup struct {

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -209,7 +209,7 @@ func (hc *HabitatController) getRunningPods(namespace, label string) ([]apiv1.Po
 	})
 	ls := fields.SelectorFromSet(fields.Set(map[string]string{
 		crv1.ServiceGroupLabel: label,
-		"topology":             "leader",
+		"topology":             crv1.TopologyLeader.String(),
 	}))
 
 	running := metav1.ListOptions{
@@ -436,15 +436,15 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 	// topology type we set standalone as the default one.
 	// We do no need to pass this to habitat, as if no topology
 	// is set, habitat by default sets standalone topology.
-	topology := string(crv1.TopologyStandalone)
+	topology := crv1.TopologyStandalone
 
 	if sg.Spec.Habitat.Topology == crv1.TopologyLeader {
-		topology = string(crv1.TopologyLeader)
+		topology = crv1.TopologyLeader
 
 		path := fmt.Sprintf("%s/%s", configMapDir, peerFilename)
 
 		habArgs = append(habArgs,
-			"--topology", topology,
+			"--topology", topology.String(),
 			"--peer-watch-file", path,
 		)
 	}
@@ -460,7 +460,7 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 					Labels: map[string]string{
 						"habitat":              "true",
 						crv1.ServiceGroupLabel: sg.Name,
-						"topology":             topology,
+						"topology":             topology.String(),
 					},
 				},
 				Spec: apiv1.PodSpec{

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -42,6 +42,8 @@ const (
 	resyncPeriod = 1 * time.Minute
 	peerFile     = "peer-ip"
 	userTomlFile = "user.toml"
+	configMapDir = "/habitat-operator"
+	peerFilename = "peer-watch-file"
 
 	// The key under which the ring key is stored in the Kubernetes Secret.
 	ringSecretKey = "ring-key"
@@ -449,7 +451,7 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 							VolumeMounts: []apiv1.VolumeMount{
 								{
 									Name:      "config",
-									MountPath: "/habitat-operator",
+									MountPath: configMapDir,
 									ReadOnly:  true,
 								},
 							},
@@ -467,7 +469,7 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 									Items: []apiv1.KeyToPath{
 										{
 											Key:  peerFile,
-											Path: peerFile,
+											Path: peerFilename,
 										},
 									},
 								},

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -445,7 +445,7 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 
 		habArgs = append(habArgs,
 			"--topology", string(topology),
-			"--peer-watch-file", string(path),
+			"--peer-watch-file", path,
 		)
 	}
 

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -40,10 +40,12 @@ import (
 
 const (
 	resyncPeriod = 1 * time.Minute
-	peerFile     = "peer-ip"
+
 	userTomlFile = "user.toml"
 	configMapDir = "/habitat-operator"
-	peerFilename = "peer-watch-file"
+
+	peerFilename = "peer-ip"
+	peerFile     = "peer-watch-file"
 
 	// The key under which the ring key is stored in the Kubernetes Secret.
 	ringSecretKey = "ring-key"

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -207,6 +207,7 @@ func (hc *HabitatController) getRunningPods(namespace, label string) ([]apiv1.Po
 	})
 	ls := fields.SelectorFromSet(fields.Set(map[string]string{
 		crv1.ServiceGroupLabel: label,
+		"topology":             "leader",
 	}))
 
 	running := metav1.ListOptions{
@@ -440,6 +441,7 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 					Labels: map[string]string{
 						"habitat":              "true",
 						crv1.ServiceGroupLabel: sg.Name,
+						"topology":             topology,
 					},
 				},
 				Spec: apiv1.PodSpec{

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -433,7 +433,7 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 
 	// As we want to label our pods with the
 	// topology type we set standalone as the default one.
-	// We do no need to pass this to habitat, as if no topology
+	// We do not need to pass this to habitat, as if no topology
 	// is set, habitat by default sets standalone topology.
 	topology := crv1.TopologyStandalone
 

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -436,15 +436,15 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 	// topology type we set standalone as the default one.
 	// We do no need to pass this to habitat, as if no topology
 	// is set, habitat by default sets standalone topology.
-	topology := crv1.TopologyStandalone
+	topology := string(crv1.TopologyStandalone)
 
 	if sg.Spec.Habitat.Topology == crv1.TopologyLeader {
-		topology = crv1.TopologyLeader
+		topology = string(crv1.TopologyLeader)
 
 		path := fmt.Sprintf("%s/%s", configMapDir, peerFilename)
 
 		habArgs = append(habArgs,
-			"--topology", string(topology),
+			"--topology", topology,
 			"--peer-watch-file", path,
 		)
 	}
@@ -460,7 +460,7 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 					Labels: map[string]string{
 						"habitat":              "true",
 						crv1.ServiceGroupLabel: sg.Name,
-						"topology":             string(topology),
+						"topology":             topology,
 					},
 				},
 				Spec: apiv1.PodSpec{

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -209,7 +209,6 @@ func (hc *HabitatController) getRunningPods(namespace, label string) ([]apiv1.Po
 	})
 	ls := fields.SelectorFromSet(fields.Set(map[string]string{
 		crv1.ServiceGroupLabel: label,
-		"topology":             crv1.TopologyLeader.String(),
 	}))
 
 	running := metav1.ListOptions{

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -457,9 +457,9 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"habitat":              "true",
+						crv1.HabitatLabel:      "true",
 						crv1.ServiceGroupLabel: sg.Name,
-						"topology":             topology.String(),
+						crv1.TopologyLabel:     topology.String(),
 					},
 				},
 				Spec: apiv1.PodSpec{

--- a/pkg/habitat/controller/utils.go
+++ b/pkg/habitat/controller/utils.go
@@ -40,7 +40,7 @@ func validateCustomObject(sg crv1.ServiceGroup) error {
 
 	switch spec.Habitat.Topology {
 	case crv1.TopologyStandalone:
-	case crv1.TopologyLeaderFollower:
+	case crv1.TopologyLeader:
 		if spec.Count < leaderFollowerTopologyMinCount {
 			return fmt.Errorf("too few instances: %s", spec.Count)
 		}


### PR DESCRIPTION
With this PR, the operator is able to handle the creation of Service Groups in a [leader-follower topology](https://www.habitat.sh/docs/run-packages-topologies/).

We do this by using a yet unreleased version of the habitat supervisor that has a [`--peer-watch-file` flag](https://github.com/habitat-sh/habitat/issues/2735).
This file is populated by the operator with the IP of a running pod, which acts as the entrypoint to the Service Group.

The habitat supervisor watches this file for changes, and when it detects them, restarts the application.

Closes #24.
Closes #25.