### PR TITLE
e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+EIP := $(shell minikube ip)
 HUB :=
 REPO := kinvolk
 IMAGE := $(if $(HUB),$(HUB)/)$(REPO)/habitat-operator
 TAG := $(shell git describe --tags --always)
+TESTIMAGE :=
 
 build:
 	go build -i github.com/kinvolk/habitat-operator/cmd/operator
@@ -13,6 +15,20 @@ image: linux
 	docker build -t "$(IMAGE):$(TAG)" .
 
 test:
-	go test -v $(shell go list ./... | grep -v /vendor/)
+	go test -v $(shell go list ./... | grep -v /vendor/ | grep -v /test/)
 
-.PHONY: build test linux image
+e2e:
+	@if test 'x$(TESTIMAGE)' = 'x'; then echo "TESTIMAGE must be passed."; exit 1; fi
+	go test -v ./test/e2e/ --image "$(TESTIMAGE)" --kubeconfig ~/.kube/config --ip "$(EIP)"
+
+clean-test:
+	kubectl delete sg mytutorialapp
+	kubectl delete sg test-service-group
+	kubectl delete sg test-standalone
+	kubectl delete crd servicegroups.habitat.sh
+	kubectl delete pod habitat-operator
+	kubectl delete secret mytutorialapp
+	kubectl delete service mytutorialapp
+	kubectl delete service test-service-group
+
+.PHONY: build test linux image e2e clean-test

--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ To run unit tests, run:
     make test
 
 [crd]: https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
+
+## Testing
+
+To run end-to-end tests you need a `minikube` up and running. After that just run:
+ 
+    make TESTIMAGE=YOUR_OPERATOR_IMAGE e2e
+
+Clean up after the tests by either running `minikube delete` (this will delete your entire cluster) or:
+
+    make clean-test

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package framework sets up the test framework needed to run the end-to-end
+// tests on Kubernetes.
+package framework
+
+import (
+	habclient "github.com/kinvolk/habitat-operator/pkg/habitat/client"
+
+	crv1 "github.com/kinvolk/habitat-operator/pkg/habitat/apis/cr/v1"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type Framework struct {
+	Image      string
+	KubeClient kubernetes.Interface
+	Client     *rest.RESTClient
+	ExternalIP string
+}
+
+// Setup sets up the test framework.
+func Setup(image, kubeconfig, externalIP string) (*Framework, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	apiclientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	cl, _, err := habclient.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	f := &Framework{
+		Image:      image,
+		KubeClient: apiclientset,
+		Client:     cl,
+		ExternalIP: externalIP,
+	}
+
+	if err = f.setupOperator(); err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+func (f *Framework) setupOperator() error {
+	name := "habitat-operator"
+	pod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				crv1.ServiceGroupLabel: name,
+			},
+		},
+		Spec: apiv1.PodSpec{
+			Containers: []apiv1.Container{
+				{
+					Name:  name,
+					Image: f.Image,
+				},
+			},
+		},
+	}
+
+	// Create pod with the Habitat operator image.
+	_, err := f.KubeClient.CoreV1().Pods(apiv1.NamespaceDefault).Create(pod)
+	if err != nil {
+		return err
+	}
+
+	// Wait until the operator is ready.
+	f.WaitForResources(name, 1)
+
+	return nil
+}

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"time"
+
+	crv1 "github.com/kinvolk/habitat-operator/pkg/habitat/apis/cr/v1"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// NewStandaloneSG returns a new Standalone ServiceGroup.
+func (f *Framework) NewStandaloneSG(sgName, group string, secret bool) *crv1.ServiceGroup {
+	sg := crv1.ServiceGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sgName,
+		},
+		Spec: crv1.ServiceGroupSpec{
+			Image: "kinvolk/nodejs-hab",
+			Count: 1,
+			Habitat: crv1.Habitat{
+				Group:    group,
+				Topology: crv1.TopologyStandalone,
+			},
+		},
+	}
+
+	if secret {
+		sg.Spec.Habitat.Config = sgName
+	}
+	return &sg
+}
+
+// CreateSG creates a ServiceGroup.
+func (f *Framework) CreateSG(sg *crv1.ServiceGroup) error {
+	return f.Client.Post().
+		Namespace(apiv1.NamespaceDefault).
+		Resource(crv1.ServiceGroupResourcePlural).
+		Body(sg).
+		Do().
+		Error()
+}
+
+// WaitForResources waits until numPods are in the "Running" state.
+// We wait for pods, because those take the longest to create.
+// Waiting for anything else would be already testing.
+func (f *Framework) WaitForResources(sgName string, numPods int) error {
+	return wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		fs := fields.SelectorFromSet(fields.Set{
+			"status.phase": "Running",
+		})
+
+		ls := labels.SelectorFromSet(labels.Set{
+			crv1.ServiceGroupLabel: sgName,
+		})
+
+		pods, err := f.KubeClient.CoreV1().Pods(apiv1.NamespaceDefault).List(metav1.ListOptions{FieldSelector: fs.String(), LabelSelector: ls.String()})
+		if err != nil {
+			return false, err
+		}
+
+		if len(pods.Items) != numPods {
+			return false, nil
+		}
+
+		return true, nil
+	})
+}
+
+func (f *Framework) WaitForEndpoints(sgName string) error {
+	return wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
+		ep, err := f.KubeClient.CoreV1().Endpoints(apiv1.NamespaceDefault).Get(sgName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if len(ep.Subsets) == 0 && len(ep.Subsets[0].Addresses) == 0 {
+			return false, nil
+		}
+
+		return true, nil
+	})
+}
+
+// DeleteSG deletes a ServiceGroup as a user would.
+func (f *Framework) DeleteSG(sgName string) error {
+	return f.Client.Delete().
+		Namespace(apiv1.NamespaceDefault).
+		Resource(crv1.ServiceGroupResourcePlural).
+		Name(sgName).
+		Do().
+		Error()
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	operatorFramework "github.com/kinvolk/habitat-operator/test/e2e/framework"
+)
+
+var framework *operatorFramework.Framework
+
+func TestMain(m *testing.M) {
+	var (
+		err  error
+		code int
+	)
+
+	image := flag.String("image", "", "habitat operator image, 'kinvolk/habitat-operator'")
+	kubeconfig := flag.String("kubeconfig", "", "path to kube config file")
+	externalIP := flag.String("ip", "", "external ip, eg. minikube ip")
+	flag.Parse()
+
+	if framework, err = operatorFramework.Setup(*image, *kubeconfig, *externalIP); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	code = m.Run()
+	os.Exit(code)
+}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	crv1 "github.com/kinvolk/habitat-operator/pkg/habitat/apis/cr/v1"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestServiceGroupCreate tests service group creation.
+func TestServiceGroupCreate(t *testing.T) {
+	sgName := "test-standalone"
+	sg := framework.NewStandaloneSG(sgName, "foobar", false)
+
+	if err := framework.CreateSG(sg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for resources to be ready.
+	if err := framework.WaitForResources(sgName, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := framework.KubeClient.CoreV1().ConfigMaps(apiv1.NamespaceDefault).Get(sgName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestServiceGroupInitialConfig tests initial configuration.
+func TestServiceGroupInitialConfig(t *testing.T) {
+	sgName := "mytutorialapp"
+	msg := "Hello from Tests!"
+	configMsg := fmt.Sprintf("message = '%s'", msg)
+
+	// Create Secret as a user would.
+	secret := &apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sgName,
+		},
+		Data: map[string][]byte{
+			"user.toml": []byte(configMsg),
+		},
+	}
+
+	_, err := framework.KubeClient.CoreV1().Secrets(apiv1.NamespaceDefault).Create(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sg := framework.NewStandaloneSG(sgName, "foobar", true)
+
+	if err := framework.CreateSG(sg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for resources to be ready.
+	if err := framework.WaitForResources(sgName, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Kubernetes Service to expose port.
+	service := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sgName,
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{
+				crv1.ServiceGroupLabel: sgName,
+			},
+			Type: "NodePort",
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{
+					Name:     "web",
+					NodePort: 30003,
+					Port:     5555,
+				},
+			},
+		},
+	}
+
+	// Create Service.
+	_, err = framework.KubeClient.CoreV1().Services(apiv1.NamespaceDefault).Create(service)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until endpoints are ready.
+	if err := framework.WaitForEndpoints(sgName); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get response from Habitat Service.
+	url := fmt.Sprintf("http://%s:30003/", framework.ExternalIP)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("We did not get a 200 OK from the deployed Habitat Service.")
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check if the msg we supplied was picked up by the Habitat Service.
+	actualMsg := string(bodyBytes)
+	if msg != actualMsg {
+		t.Fatalf("Initial Configuration failed. Msg did not match the one expected. Expected: %s got: %s", msg, actualMsg)
+	}
+}
+
+// TestServiceGroupFunctioning tests that operator deploys a habitat service and that it has started.
+func TestServiceGroupFunctioning(t *testing.T) {
+	sgName := "test-service-group"
+	sg := framework.NewStandaloneSG(sgName, "foobar", false)
+
+	if err := framework.CreateSG(sg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for resources to be ready.
+	if err := framework.WaitForResources(sgName, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Kubernetes Service to expose port.
+	service := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sgName,
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{
+				crv1.ServiceGroupLabel: sgName,
+			},
+			Type: "NodePort",
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{
+					Name:     "web",
+					NodePort: 30002,
+					Port:     5555,
+				},
+			},
+		},
+	}
+	// Create Service.
+	_, err := framework.KubeClient.CoreV1().Services(apiv1.NamespaceDefault).Create(service)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until endpoints are ready.
+	if err := framework.WaitForEndpoints(sgName); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get response from Habitat Service.
+	url := fmt.Sprintf("http://%s:30002/", framework.ExternalIP)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("Habitat Service did not start correctly.")
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This msg is set in the default.toml in kinvolk/nodejs-hab Habitat Service.
+	expectedMsg := "Hello, World!"
+	actualMsg := string(bodyBytes)
+	if expectedMsg != actualMsg {
+		t.Fatalf("Habitat Service msg does not match one in default.toml. Expected: %s got: %s", expectedMsg, actualMsg)
+	}
+}
+
+// TestServiceGroupDelete tests Service Group deletion.
+func TestServiceGroupDelete(t *testing.T) {
+	sgName := "test-deletion"
+	sg := framework.NewStandaloneSG(sgName, "foobar", false)
+
+	if err := framework.CreateSG(sg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for resources to be ready.
+	if err := framework.WaitForResources(sgName, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete SG.
+	if err := framework.DeleteSG(sgName); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for resources to be deleted.
+	if err := framework.WaitForResources(sgName, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check if all the resources the operator creates are deleted.
+	// We do not care about secrets being deleted, as the user needs to delete those manually.
+	d, err := framework.KubeClient.AppsV1beta1().Deployments(apiv1.NamespaceDefault).Get(sgName, metav1.GetOptions{})
+	if err == nil && d != nil {
+		t.Fatal("Deployment was not deleted.")
+	}
+
+	cm, err := framework.KubeClient.CoreV1().ConfigMaps(apiv1.NamespaceDefault).Get(sgName, metav1.GetOptions{})
+	if err == nil && cm != nil {
+		t.Fatal("ConfigMap was not deleted.")
+	}
+}


### PR DESCRIPTION
This PR introduces end to end tests. Tests currently can only be run locally, but in the future we can add so they can be run when PR is opened.

To run the tests:
```
make TESTIMAGE=YOUR_OPERATOR_IMAGE e2e
```

Closes https://github.com/kinvolk/habitat-operator/issues/54.