### PR TITLE
Skip ConfigMap handling if topology is not leader-follower

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -207,7 +207,9 @@ func (hc *HabitatController) getRunningPods(namespace, label string) ([]apiv1.Po
 	fs := fields.SelectorFromSet(fields.Set{
 		"status.phase": "Running",
 	})
-	ls := fields.SelectorFromSet(fields.Set(map[string]string{
+	ls := labels.SelectorFromSet(labels.Set(map[string]string{
+		crv1.HabitatLabel:      "true",
+		crv1.TopologyLabel:     crv1.TopologyLeader.String(),
 		crv1.ServiceGroupLabel: label,
 	}))
 

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -391,6 +391,12 @@ func (hc *HabitatController) onPodUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
+	// Nothing needs to be done if the topology is not leader-follower, since
+	// there is no ConfigMap to update.
+	if sg.Spec.Habitat.Topology != crv1.TopologyLeader {
+		return
+	}
+
 	hc.enqueueSG(sg)
 }
 
@@ -411,6 +417,12 @@ func (hc *HabitatController) onPodDelete(obj interface{}) {
 		// This only means the Pod and the ServiceGroup watchers are not in sync.
 		level.Debug(hc.logger).Log("msg", "ServiceGroup not found", "function", "onPodDelete")
 
+		return
+	}
+
+	// Nothing needs to be done if the topology is not leader-follower, since
+	// there is no ConfigMap to update.
+	if sg.Spec.Habitat.Topology != crv1.TopologyLeader {
 		return
 	}
 


### PR DESCRIPTION
This affects the watcher, in that we are only interested in watching pods if there is work to do in relation to the ConfigMap, and it affects the `syncServiceGroup` method, because it looks for Pods as part of its ConfigMap handling logic.

Closes #49.