### PR TITLE
Fix ring name passed as flag argument

### DIFF
--- a/examples/encrypted/README.md
+++ b/examples/encrypted/README.md
@@ -12,14 +12,14 @@ for platform-specific instructions on base64 encoding).
 The encoded key can then be used as the value of the `ring-key` key in a Kubernetes
 secret.
 
-The secret's name should be the same as the filename of the key, minus the
+The secret's name must be the same as the filename of the key, minus the
 extension.
 
 For example, for a key named `foobar`, the key file might be something like
-`foobar-20170824094632.sym.key`, and the secret name should be
+`foobar-20170824094632.sym.key`, and the secret name must be
 `foobar-20170824094632`.
 
-The secret's name must additionally be referenced in the `ServiceGroup` object's `ringKey`
+The secret's name must additionally be referenced in the `ServiceGroup` object's `ringSecretName`
 key.
 
 ## Deletion

--- a/examples/encrypted/service_group.yml
+++ b/examples/encrypted/service_group.yml
@@ -1,14 +1,15 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ring-key-20170816102049
+  # the name must mirror the ring filename, without the extension
+  name: example-encrypted-ring-20170829113029
   labels:
     habitat: "true"
     ring-key: "true"
 type: Opaque
 data:
   # base64-encoded ring key
-  ring-key: U1lNLVNFQy0xCnJpbmcta2V5LTIwMTcwODE2MTAyMDQ5CgpyTmtKbkJxZHppVWdmdnYweEVhaWpzMWxHUGZUdHBLdFg0L0xaMmpQcWdJPQo=
+  ring-key: U1lNLVNFQy0xCmV4YW1wbGUtZW5jcnlwdGVkLXJpbmctMjAxNzA4MjkxMTMwMjkKClFGZm9ZTHJOV3NNRk93Tk4wb0F1d3d4WjA1aVBMdTQxSUdGSzJISVFqTlk9
 ---
 apiVersion: habitat.sh/v1
 kind: ServiceGroup
@@ -21,4 +22,4 @@ spec:
   habitat:
     topology: leader
     # the name of the secret containing the ring key
-    ringKey: ring-key-20170816102049
+    ringSecretName: example-encrypted-ring-20170829113029

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -61,7 +61,7 @@ type Habitat struct {
 	Config string `json:"config"`
 	// The name of the secret that contains the ring key.
 	// Optional.
-	RingKey string `json:"ringKey,omitempty"`
+	RingSecretName string `json:"ringSecretName,omitempty"`
 }
 
 type Topology string

--- a/pkg/habitat/controller/utils.go
+++ b/pkg/habitat/controller/utils.go
@@ -48,6 +48,16 @@ func validateCustomObject(sg crv1.ServiceGroup) error {
 		return fmt.Errorf("unkown topology: %s", spec.Habitat.Topology)
 	}
 
+	if rsn := spec.Habitat.RingSecretName; rsn != "" {
+		ringParts := ringRegexp.FindStringSubmatch(rsn)
+
+		// The ringParts slice should have a second element for the capturing group
+		// in the ringRegexp regular expression, containing the ring's name.
+		if len(ringParts) < 2 {
+			return fmt.Errorf("malformed ring secret name: %s", rsn)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The argument we were passing included the revision, whereas habitat only
expects the ring name.

* Before: `--ring foobar-12312313`
* After: `--ring foobar`