### PR TITLE
Minor fixes and improvments

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -44,6 +44,7 @@ func run() int {
 
 	// Set up logging.
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger = log.With(logger, "ts", log.DefaultTimestamp)
 
 	if *verbose {
 		logger = level.NewFilter(logger, level.AllowDebug())

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -26,7 +26,6 @@ import (
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	habitatclient "github.com/kinvolk/habitat-operator/pkg/habitat/client"
@@ -53,7 +52,7 @@ func run() int {
 	}
 
 	// Build operator config.
-	config, err := buildConfig(*kubeconfig)
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	if err != nil {
 		level.Error(logger).Log("msg", err)
 		return 1
@@ -123,12 +122,4 @@ func run() int {
 
 func main() {
 	os.Exit(run())
-}
-
-func buildConfig(kubeconfig string) (*rest.Config, error) {
-	if kubeconfig != "" {
-		return clientcmd.BuildConfigFromFlags("", kubeconfig)
-	}
-
-	return rest.InClusterConfig()
 }

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -137,13 +137,13 @@ func (hc *HabitatController) watchServiceGroups(ctx context.Context) {
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				oldSG, ok := oldObj.(*crv1.ServiceGroup)
 				if !ok {
-					level.Error(hc.logger).Log("msg", "Failed to type assert pod", "obj", oldObj)
+					level.Error(hc.logger).Log("msg", "Failed to type assert ServiceGroup", "obj", oldObj)
 					return
 				}
 
 				newSG, ok := newObj.(*crv1.ServiceGroup)
 				if !ok {
-					level.Error(hc.logger).Log("msg", "Failed to type assert pod", "obj", newObj)
+					level.Error(hc.logger).Log("msg", "Failed to type assert ServiceGroup", "obj", newObj)
 					return
 				}
 


### PR DESCRIPTION
This PR:
- adds a timestamp to our logs, thought it would be valuable, when trying things out locally, I find it very useful to see when things were created, deleted, etc.

- removes `buildConfig ` as that check is already done in `BuildConfigFromFlags` function.
https://github.com/kinvolk/habitat-operator/blob/57b46f7cc225c87434432e6ccec1221f34eeb8e1/vendor/k8s.io/client-go/tools/clientcmd/client_config.go#L527-L534