### PR TITLE
Rename CRD from ServiceGroup to Habitat

### DIFF
--- a/cmd/habitat-operator/main.go
+++ b/cmd/habitat-operator/main.go
@@ -66,7 +66,7 @@ func run() int {
 		return 1
 	}
 
-	// Create ServiceGroup CRD.
+	// Create Habitat CRD.
 	_, crdErr := habitatclient.CreateCRD(apiextensionsclientset)
 	if crdErr != nil {
 		if !apierrors.IsAlreadyExists(crdErr) {
@@ -74,9 +74,9 @@ func run() int {
 			return 1
 		}
 
-		level.Info(logger).Log("msg", "ServiceGroup CRD already exists, continuing")
+		level.Info(logger).Log("msg", "Habitat CRD already exists, continuing")
 	} else {
-		level.Info(logger).Log("msg", "created ServiceGroup CRD")
+		level.Info(logger).Log("msg", "created Habitat CRD")
 	}
 
 	habitatClient, scheme, err := habitatclient.NewClient(config)

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,23 +2,23 @@
 
 The following is a description of the Habitat operator API. To see manifest example files, have a look at the [examples directory](https://github.com/kinvolk/habitat-operator/tree/master/examples).
 
-## ServiceGroup
+## Habitat
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | metadata |  | [metav1.ObjectMeta](https://kubernetes.io/docs/api-reference/v1.6/#objectmeta-v1-meta) | true |
-| spec |  | [ServiceGroupSpec](#servicegroupspec) | true |
+| spec |  | [HabitatSpec](#habitatspec) | true |
 | status |  |  | false |
 
-## ServiceGroupSpec
+## HabitatSpec
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| count | Count is the amount of Services that should start in this Service Group. | int | true |
+| count | Count is the amount of Services that should start in Habitat. | int | true |
 | image | Image is the Docker image of the Habitat Service. | string | true |
-| habitat |  | [Habitat](#habitat) | true |
+| service |  | [Service](#service) | true |
 
-## Habitat
+## Service
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |

--- a/examples/bind/README.md
+++ b/examples/bind/README.md
@@ -7,9 +7,9 @@ This demonstrates how to run two Habitat Services with a [binding](https://www.h
 After the Habitat operator is up and running, execute the following command from the root of this repository:
 
 ```
-kubectl create -f examples/bind/service_group.yml
+kubectl create -f examples/bind/habitat.yml
 ```
 
-This will deploy two `ServiceGroup`s, a simple HTTP server written in Go that will be bound to a PostgreSQL database. The Go server will display the port number the database listens on.
+This will deploy two `Habitat`s, a simple HTTP server written in Go that will be bound to a PostgreSQL database. The Go server will display the port number the database listens on.
 
 When running on minikube, it can be accessed under port `5555` of the minikube VM. `minikube ip` can be used to retrieve the IP.

--- a/examples/bind/habitat.yml
+++ b/examples/bind/habitat.yml
@@ -1,21 +1,21 @@
 apiVersion: habitat.sh/v1
-kind: ServiceGroup
+kind: Habitat 
 metadata:
   name: db
 spec:
   image: kinvolk/postgresql-hab
   count: 1
-  habitat:
+  service:
     topology: standalone
 ---
 apiVersion: habitat.sh/v1
-kind: ServiceGroup
+kind: Habitat
 metadata:
   name: go
 spec:
   image: kinvolk/bindgo-hab
   count: 1
-  habitat:
+  service:
     topology: standalone
     bind:
       # Name is the name of the bind specified in the Habitat configuration files.
@@ -31,7 +31,7 @@ metadata:
   name: go-service
 spec:
   selector:
-    service-group: go
+    habitat-name: go
   type: NodePort
   ports:
   - name: web

--- a/examples/config/README.md
+++ b/examples/config/README.md
@@ -7,14 +7,14 @@ NOTE: Adding secret configuration to the `default.toml` is discouraged, as it wi
 
 After the Habitat operator is up and running, execute the following command from the root of this repository:
 
-`kubectl create -f examples/config/service_group.yml`
+`kubectl create -f examples/config/habitat.yml`
 
 This will create a [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/) with the configurations and a simple Node.js application that will display a msg. When running on minikube, it can be accessed under port `30001` of the minikube VM. `minikube ip` can be used to retrieve the IP.
 Initially our app is configured to display the msg `"Hello world."`. Because we override this with the Secret we just created, our app will instead display `Hello from our Habitat-Operator!`.
 
 ## Deletion
 
-The Habitat operator does not delete the Secret on ServiceGroup deletion, as it is not managed by the Habitat operator.
+The Habitat operator does not delete the Secret on Habitat deletion, as it is not managed by the Habitat operator.
 To manually delete the Secret simply run:
 
 ```

--- a/examples/config/habitat.yml
+++ b/examples/config/habitat.yml
@@ -10,14 +10,14 @@ data:
   user.toml: bWVzc2FnZSA9ICdIZWxsbyBmcm9tIG91ciBIYWJpdGF0LU9wZXJhdG9yISc=
 ---
 apiVersion: habitat.sh/v1
-kind: ServiceGroup
+kind: Habitat
 metadata:
   # Name must be the same as your service name in Habitat.
   name: mytutorialapp
 spec:
   image: kinvolk/nodejs-hab
   count: 1
-  habitat:
+  service:
     topology: standalone
     group: nodejs
     # Create Secret with the initial configuration you want.
@@ -29,7 +29,7 @@ metadata:
   name: mytutorialapp
 spec:
   selector:
-    service-group: mytutorialapp
+    habitat-name: mytutorialapp
   type: NodePort
   ports:
   # This endpoint displays the message from the secret

--- a/examples/crd.yml
+++ b/examples/crd.yml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: servicegroups.habitat.sh
+  name: habitats.habitat.sh
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: habitat.sh
@@ -12,11 +12,11 @@ spec:
   scope: Namespaced
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>
-    plural: servicegroups
+    plural: habitats
     # singular name to be used as an alias on the CLI and for display
-    singular: servicegroup
+    singular: habitat
     # kind is normally the CamelCased singular type. Your resource manifests use this.
-    kind: ServiceGroup
+    kind: Habitat
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
-    - sg
+    - hab

--- a/examples/encrypted/README.md
+++ b/examples/encrypted/README.md
@@ -1,4 +1,4 @@
-# Encrypted ServiceGroup example
+# Encrypted Habitat example
 
 By default supervisors will communicate with no encryption. This example demostrates how to secure the communication.
 
@@ -21,19 +21,19 @@ For example, for a key named `foobar`, the key file might be something like
 `foobar-20170824094632.sym.key`, and the secret name must be
 `foobar-20170824094632`.
 
-The secret's name must additionally be referenced in the `ServiceGroup` object's `ringSecretName` key.
+The secret's name must additionally be referenced in the `Habitat` object's `ringSecretName` key.
 
 After the Habitat operator is up and running, execute the following command from the root of this repository:
 
 ```
-kubectl create -f examples/encrypted/service_group.yml
+kubectl create -f examples/encrypted/habitat.yml
 ```
 
 ## Deletion
 
-The Habitat operator does not delete the Secret on ServiceGroup deletion. This is
+The Habitat operator does not delete the Secret on Habitat deletion. This is
 because the user might want to re-use the secret across multiple
-`ServiceGroup`s and `ServiceGroup` lifecycles.
+`Habitat`s and `Habitat` lifecycles.
 
 To delete the Secret simply run:
 

--- a/examples/encrypted/habitat.yml
+++ b/examples/encrypted/habitat.yml
@@ -12,14 +12,14 @@ data:
   ring-key: U1lNLVNFQy0xCmV4YW1wbGUtZW5jcnlwdGVkLXJpbmctMjAxNzA4MjkxMTMwMjkKClFGZm9ZTHJOV3NNRk93Tk4wb0F1d3d4WjA1aVBMdTQxSUdGSzJISVFqTlk9
 ---
 apiVersion: habitat.sh/v1
-kind: ServiceGroup
+kind: Habitat
 metadata:
-  name: example-encrypted-service-group
+  name: example-encrypted-habitat
 spec:
   # the core/nginx habitat service packaged as a Docker image
   image: kinvolk/consul-hab
   count: 3
-  habitat:
+  service:
     topology: leader
     # the name of the secret containing the ring key
     ringSecretName: example-encrypted-ring-20170829113029

--- a/examples/leader/README.md
+++ b/examples/leader/README.md
@@ -6,9 +6,9 @@ A topology describes the intended relationship between members within a Habitat 
 
 Simply run:
 
-  `kubectl create -f examples/leader/service_group.yml`.
+  `kubectl create -f examples/leader/habitat.yml`.
 
 This will deploy 3 instances of consul Habitat service.
 
-Note: Whenever creating a `leader` topology ServiceGroup you have to specify `count` 3 or more and would be best if the number is odd, this is so the election can take place.
+Note: Whenever creating a `leader` topology specify instance `count` of 3 or more and would be best if the number is odd, this is so the election can take place.
 

--- a/examples/leader/habitat.yml
+++ b/examples/leader/habitat.yml
@@ -1,13 +1,13 @@
 apiVersion: habitat.sh/v1
-kind: ServiceGroup
+kind: Habitat
 metadata:
-  name: example-leader-follower-service-group
+  name: example-leader-follower-habitat
 spec:
   # the core/consul habitat service packaged as a Docker image
   image: kinvolk/consul-hab
   # count must be at least 3 for a leader-follower topology
   count: 3
-  habitat:
+  service:
     topology: leader
     # if not present, defaults to "default"
     group: foobar

--- a/examples/namespaced/README.md
+++ b/examples/namespaced/README.md
@@ -1,4 +1,4 @@
-# Namespaced ServiceGroup example
+# Namespaced Habitat example
 
 This demonstrates how to deploy service in a [Kubernetes namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 
@@ -6,6 +6,6 @@ This demonstrates how to deploy service in a [Kubernetes namespace](https://kube
 
 Simply run:
 
- `kubectl create -f examples/namespaced/service_group.yml`.
+ `kubectl create -f examples/namespaced/habitat.yml`.
 
-Note that any Secrets used by a `ServiceGroup` must be in the same namespace as the `ServiceGroup` itself.
+Note that any Secrets used by a `Habitat` must be in the same namespace as the `Habitat` itself.

--- a/examples/namespaced/habitat.yml
+++ b/examples/namespaced/habitat.yml
@@ -4,15 +4,15 @@ metadata:
   name: example-namespace
 ---
 apiVersion: habitat.sh/v1
-kind: ServiceGroup
+kind: Habitat
 metadata:
-  name: example-standalone-service-group
+  name: example-standalone-habitat
   namespace: example-namespace
 spec:
   # the core/nginx habitat service packaged as a Docker image
   image: kinvolk/nginx-hab
   count: 1
-  habitat:
+  service:
     topology: standalone
     # if not present, defaults to "default"
     group: foobar

--- a/examples/standalone/README.md
+++ b/examples/standalone/README.md
@@ -7,6 +7,6 @@ A topology describes the intended relationship between members within a Habitat 
 
 Simply run:
 
-  `kubectl create -f examples/standalone/service_group.yml`.
+  `kubectl create -f examples/standalone/habitat.yml`.
 
 This will deploy an instance of an nginx Habitat service.

--- a/examples/standalone/habitat.yml
+++ b/examples/standalone/habitat.yml
@@ -1,12 +1,12 @@
 apiVersion: habitat.sh/v1
-kind: ServiceGroup
+kind: Habitat
 metadata:
-  name: example-standalone-service-group
+  name: example-standalone-habitat
 spec:
   # the core/nginx habitat service packaged as a Docker image
   image: kinvolk/nginx-hab
   count: 1
-  habitat:
+  service:
     topology: standalone
     # if not present, defaults to "default"
     group: foobar

--- a/pkg/habitat/apis/cr/v1/register.go
+++ b/pkg/habitat/apis/cr/v1/register.go
@@ -39,8 +39,8 @@ func Resource(resource string) schema.GroupResource {
 // addKnownTypes adds the set of types defined in this package to the supplied scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
-		&ServiceGroup{},
-		&ServiceGroupList{},
+		&Habitat{},
+		&HabitatList{},
 	)
 
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -19,37 +19,41 @@ import (
 )
 
 const (
-	ServiceGroupResourcePlural = "servicegroups"
-	ServiceGroupLabel          = "service-group"
+	HabitatResourcePlural = "habitats"
+
+	// HabitatLabel labels the resources that belong to Habitat.
+	// Example: 'habitat: true'
+	HabitatLabel = "habitat"
+	// HabitatNameLabel contains the user defined Habitat Service name.
+	// Example: 'habitat-name: db'
+	HabitatNameLabel = "habitat-name"
 
 	TopologyLabel = "topology"
-
-	HabitatLabel = "habitat"
 )
 
-type ServiceGroup struct {
+type Habitat struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
-	Spec              ServiceGroupSpec   `json:"spec"`
-	Status            ServiceGroupStatus `json:"status,omitempty"`
+	Spec              HabitatSpec   `json:"spec"`
+	Status            HabitatStatus `json:"status,omitempty"`
 }
 
-type ServiceGroupSpec struct {
-	// Count is the amount of Services to start in this Service Group.
+type HabitatSpec struct {
+	// Count is the amount of Services to start in this Habitat.
 	Count int `json:"count"`
 	// Image is the Docker image of the Habitat Service.
 	Image   string  `json:"image"`
-	Habitat Habitat `json:"habitat"`
+	Service Service `json:"service"`
 }
 
-type ServiceGroupStatus struct {
-	State   ServiceGroupState `json:"state,omitempty"`
-	Message string            `json:"message,omitempty"`
+type HabitatStatus struct {
+	State   HabitatState `json:"state,omitempty"`
+	Message string       `json:"message,omitempty"`
 }
 
-type ServiceGroupState string
+type HabitatState string
 
-type Habitat struct {
+type Service struct {
 	// Group is the value of the --group flag for the hab client.
 	// Optional. Defaults to `default`.
 	Group string `json:"group"`
@@ -83,15 +87,15 @@ func (t Topology) String() string {
 }
 
 const (
-	ServiceGroupStateCreated   ServiceGroupState = "Created"
-	ServiceGroupStateProcessed ServiceGroupState = "Processed"
+	HabitatStateCreated   HabitatState = "Created"
+	HabitatStateProcessed HabitatState = "Processed"
 
 	TopologyStandalone Topology = "standalone"
 	TopologyLeader     Topology = "leader"
 )
 
-type ServiceGroupList struct {
+type HabitatList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
-	Items           []ServiceGroup `json:"items"`
+	Items           []Habitat `json:"items"`
 }

--- a/pkg/habitat/apis/cr/v1/types_test.go
+++ b/pkg/habitat/apis/cr/v1/types_test.go
@@ -26,17 +26,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
-var _ runtime.Object = &ServiceGroup{}
-var _ metav1.ObjectMetaAccessor = &ServiceGroup{}
+var _ runtime.Object = &Habitat{}
+var _ metav1.ObjectMetaAccessor = &Habitat{}
 
-var _ runtime.Object = &ServiceGroupList{}
-var _ metav1.ListMetaAccessor = &ServiceGroupList{}
+var _ runtime.Object = &HabitatList{}
+var _ metav1.ListMetaAccessor = &HabitatList{}
 
-func serviceGroupFuzzerFuncs(t apitesting.TestingCommon) []interface{} {
+func habitatFuzzerFuncs(t apitesting.TestingCommon) []interface{} {
 	return []interface{}{
-		func(obj *ServiceGroupList, c fuzz.Continue) {
+		func(obj *HabitatList, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)
-			obj.Items = make([]ServiceGroup, c.Intn(10))
+			obj.Items = make([]Habitat, c.Intn(10))
 			for i := range obj.Items {
 				c.Fuzz(&obj.Items[i])
 			}
@@ -53,9 +53,9 @@ func TestRoundTrip(t *testing.T) {
 	AddToScheme(scheme)
 
 	seed := rand.Int63()
-	fuzzerFuncs := apitesting.MergeFuzzerFuncs(t, apitesting.GenericFuzzerFuncs(t, codecs), serviceGroupFuzzerFuncs(t))
+	fuzzerFuncs := apitesting.MergeFuzzerFuncs(t, apitesting.GenericFuzzerFuncs(t, codecs), habitatFuzzerFuncs(t))
 	fuzzer := apitesting.FuzzerFor(fuzzerFuncs, rand.NewSource(seed))
 
-	apitesting.RoundTripSpecificKindWithoutProtobuf(t, SchemeGroupVersion.WithKind("ServiceGroup"), scheme, codecs, fuzzer, nil)
-	apitesting.RoundTripSpecificKindWithoutProtobuf(t, SchemeGroupVersion.WithKind("ServiceGroupList"), scheme, codecs, fuzzer, nil)
+	apitesting.RoundTripSpecificKindWithoutProtobuf(t, SchemeGroupVersion.WithKind("Habitat"), scheme, codecs, fuzzer, nil)
+	apitesting.RoundTripSpecificKindWithoutProtobuf(t, SchemeGroupVersion.WithKind("HabitatList"), scheme, codecs, fuzzer, nil)
 }

--- a/pkg/habitat/client/cr.go
+++ b/pkg/habitat/client/cr.go
@@ -29,28 +29,28 @@ import (
 )
 
 const (
-	serviceGroupCRDName           = crv1.ServiceGroupResourcePlural + "." + crv1.GroupName
-	serviceGroupResourceShortName = "sg"
+	habitatCRDName           = crv1.HabitatResourcePlural + "." + crv1.GroupName
+	habitatResourceShortName = "hab"
 
 	pollInterval = 500 * time.Millisecond
 	timeOut      = 10 * time.Second
 )
 
-// CreateCRD creates the ServiceGroup Custom Resource Definition.
+// CreateCRD creates the Habitat Custom Resource Definition.
 // It checks if creation has completed successfully, and deletes the CRD in case of error.
 func CreateCRD(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: serviceGroupCRDName,
+			Name: habitatCRDName,
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   crv1.GroupName,
 			Version: crv1.SchemeGroupVersion.Version,
 			Scope:   apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:     crv1.ServiceGroupResourcePlural,
-				Kind:       reflect.TypeOf(crv1.ServiceGroup{}).Name(),
-				ShortNames: []string{serviceGroupResourceShortName},
+				Plural:     crv1.HabitatResourcePlural,
+				Kind:       reflect.TypeOf(crv1.Habitat{}).Name(),
+				ShortNames: []string{habitatResourceShortName},
 			},
 		},
 	}
@@ -62,7 +62,7 @@ func CreateCRD(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.C
 
 	// wait for CRD being established.
 	err = wait.Poll(pollInterval, timeOut, func() (bool, error) {
-		crd, err = clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(serviceGroupCRDName, metav1.GetOptions{})
+		crd, err = clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(habitatCRDName, metav1.GetOptions{})
 
 		if err != nil {
 			return false, err
@@ -87,7 +87,7 @@ func CreateCRD(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.C
 
 	// delete CRD if there was an error.
 	if err != nil {
-		deleteErr := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(serviceGroupCRDName, nil)
+		deleteErr := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(habitatCRDName, nil)
 		if deleteErr != nil {
 			return nil, errors.NewAggregate([]error{err, deleteErr})
 		}
@@ -98,17 +98,17 @@ func CreateCRD(clientset apiextensionsclient.Interface) (*apiextensionsv1beta1.C
 	return crd, nil
 }
 
-// WaitForServiceGroupInstanceProcessed polls the API for a specific ServiceGroup with a state of "Processed".
-func WaitForServiceGroupInstanceProcessed(client *rest.RESTClient, name string) error {
+// WaitForHabitatInstanceProcessed polls the API for a specific Habitat with a state of "Processed".
+func WaitForHabitatInstanceProcessed(client *rest.RESTClient, name string) error {
 	return wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
-		var sg crv1.ServiceGroup
+		var hab crv1.Habitat
 		err := client.Get().
-			Resource(crv1.ServiceGroupResourcePlural).
+			Resource(crv1.HabitatResourcePlural).
 			Namespace(apiv1.NamespaceDefault).
 			Name(name).
-			Do().Into(&sg)
+			Do().Into(&hab)
 
-		if err == nil && sg.Status.State == crv1.ServiceGroupStateProcessed {
+		if err == nil && hab.Status.State == crv1.HabitatStateProcessed {
 			return true, nil
 		}
 

--- a/pkg/habitat/controller/utils.go
+++ b/pkg/habitat/controller/utils.go
@@ -27,28 +27,28 @@ import (
 
 const leaderFollowerTopologyMinCount = 3
 
-type serviceGroupNotFoundError struct {
+type habitatNotFoundError struct {
 	key string
 }
 
-func (err serviceGroupNotFoundError) Error() string {
-	return fmt.Sprintf("could not find ServiceGroup with key %s", err.key)
+func (err habitatNotFoundError) Error() string {
+	return fmt.Sprintf("could not find Habitat with key %s", err.key)
 }
 
-func validateCustomObject(sg crv1.ServiceGroup) error {
-	spec := sg.Spec
+func validateCustomObject(h crv1.Habitat) error {
+	spec := h.Spec
 
-	switch spec.Habitat.Topology {
+	switch spec.Service.Topology {
 	case crv1.TopologyStandalone:
 	case crv1.TopologyLeader:
 		if spec.Count < leaderFollowerTopologyMinCount {
 			return fmt.Errorf("too few instances: %d, leader-follower topology requires at least %d", spec.Count, leaderFollowerTopologyMinCount)
 		}
 	default:
-		return fmt.Errorf("unkown topology: %s", spec.Habitat.Topology)
+		return fmt.Errorf("unkown topology: %s", spec.Service.Topology)
 	}
 
-	if rsn := spec.Habitat.RingSecretName; rsn != "" {
+	if rsn := spec.Service.RingSecretName; rsn != "" {
 		ringParts := ringRegexp.FindStringSubmatch(rsn)
 
 		// The ringParts slice should have a second element for the capturing group

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -86,7 +86,7 @@ func (f *Framework) setupOperator() error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				crv1.ServiceGroupLabel: name,
+				crv1.HabitatNameLabel: name,
 			},
 		},
 		Spec: apiv1.PodSpec{

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -36,17 +36,17 @@ const (
 	nodejsImage = "kinvolk/nodejs-hab:test"
 )
 
-// TestServiceGroupCreate tests service group creation.
-func TestServiceGroupCreate(t *testing.T) {
-	sgName := "test-standalone"
-	sg := utils.NewStandaloneSG(sgName, "foobar", nodejsImage)
+// TestHabitatCreate tests Habitat creation.
+func TestHabitatCreate(t *testing.T) {
+	habitatName := "test-standalone"
+	habitat := utils.NewStandaloneHabitat(habitatName, "foobar", nodejsImage)
 
-	if err := framework.CreateSG(sg); err != nil {
+	if err := framework.CreateHabitat(habitat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for resources to be ready.
-	if err := framework.WaitForResources(sgName, 1); err != nil {
+	if err := framework.WaitForResources(habitatName, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,16 +56,16 @@ func TestServiceGroupCreate(t *testing.T) {
 	}
 }
 
-// TestServiceGroupInitialConfig tests initial configuration.
-func TestServiceGroupInitialConfig(t *testing.T) {
-	sgName := "mytutorialapp"
+// TestHabitatInitialConfig tests initial configuration.
+func TestHabitatInitialConfig(t *testing.T) {
+	habitatName := "mytutorialapp"
 	msg := "Hello from Tests!"
 	configMsg := fmt.Sprintf("message = '%s'", msg)
 
 	// Create Secret as a user would.
 	secret := &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: sgName,
+			Name: habitatName,
 		},
 		Data: map[string][]byte{
 			"user.toml": []byte(configMsg),
@@ -77,26 +77,26 @@ func TestServiceGroupInitialConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sg := utils.NewStandaloneSG(sgName, "foobar", nodejsImage)
-	utils.AddConfigToSG(sg)
+	habitat := utils.NewStandaloneHabitat(habitatName, "foobar", nodejsImage)
+	utils.AddConfigToHabitat(habitat)
 
-	if err := framework.CreateSG(sg); err != nil {
+	if err := framework.CreateHabitat(habitat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for resources to be ready.
-	if err := framework.WaitForResources(sgName, 1); err != nil {
+	if err := framework.WaitForResources(habitatName, 1); err != nil {
 		t.Fatal(err)
 	}
 
 	// Create Kubernetes Service to expose port.
 	service := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: sgName,
+			Name: habitatName,
 		},
 		Spec: apiv1.ServiceSpec{
 			Selector: map[string]string{
-				crv1.ServiceGroupLabel: sgName,
+				crv1.HabitatNameLabel: habitatName,
 			},
 			Type: "NodePort",
 			Ports: []apiv1.ServicePort{
@@ -116,7 +116,7 @@ func TestServiceGroupInitialConfig(t *testing.T) {
 	}
 
 	// Wait until endpoints are ready.
-	if err := framework.WaitForEndpoints(sgName); err != nil {
+	if err := framework.WaitForEndpoints(habitatName); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(waitForPorts)
@@ -145,33 +145,33 @@ func TestServiceGroupInitialConfig(t *testing.T) {
 	}
 
 	// Delete Service so it doesn't interfere with other tests.
-	if err := framework.DeleteService(sgName); err != nil {
+	if err := framework.DeleteService(habitatName); err != nil {
 		t.Fatal(err)
 	}
 }
 
-// TestServiceGroupFunctioning tests that operator deploys a habitat service and that it has started.
-func TestServiceGroupFunctioning(t *testing.T) {
-	sgName := "test-service-group"
-	sg := utils.NewStandaloneSG(sgName, "foobar", nodejsImage)
+// TestHabitatFunctioning tests that operator deploys a Habitat service and that it has started.
+func TestHabitatFunctioning(t *testing.T) {
+	habitatName := "test-habitat"
+	habitat := utils.NewStandaloneHabitat(habitatName, "foobar", nodejsImage)
 
-	if err := framework.CreateSG(sg); err != nil {
+	if err := framework.CreateHabitat(habitat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for resources to be ready.
-	if err := framework.WaitForResources(sgName, 1); err != nil {
+	if err := framework.WaitForResources(habitatName, 1); err != nil {
 		t.Fatal(err)
 	}
 
 	// Create Kubernetes Service to expose port.
 	service := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: sgName,
+			Name: habitatName,
 		},
 		Spec: apiv1.ServiceSpec{
 			Selector: map[string]string{
-				crv1.ServiceGroupLabel: sgName,
+				crv1.HabitatNameLabel: habitatName,
 			},
 			Type: "NodePort",
 			Ports: []apiv1.ServicePort{
@@ -190,7 +190,7 @@ func TestServiceGroupFunctioning(t *testing.T) {
 	}
 
 	// Wait until endpoints are ready.
-	if err := framework.WaitForEndpoints(sgName); err != nil {
+	if err := framework.WaitForEndpoints(habitatName); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(waitForPorts)
@@ -220,43 +220,43 @@ func TestServiceGroupFunctioning(t *testing.T) {
 	}
 
 	// Delete Service so it doesn't interfere with other tests.
-	if err := framework.DeleteService(sgName); err != nil {
+	if err := framework.DeleteService(habitatName); err != nil {
 		t.Fatal(err)
 	}
 }
 
-// TestServiceGroupDelete tests Service Group deletion.
-func TestServiceGroupDelete(t *testing.T) {
-	sgName := "test-deletion"
-	sg := utils.NewStandaloneSG(sgName, "foobar", nodejsImage)
+// TestHabitatDelete tests Habitat deletion.
+func TestHabitatDelete(t *testing.T) {
+	habitatName := "test-deletion"
+	habitat := utils.NewStandaloneHabitat(habitatName, "foobar", nodejsImage)
 
-	if err := framework.CreateSG(sg); err != nil {
+	if err := framework.CreateHabitat(habitat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for resources to be ready.
-	if err := framework.WaitForResources(sgName, 1); err != nil {
+	if err := framework.WaitForResources(habitatName, 1); err != nil {
 		t.Fatal(err)
 	}
 
-	// Delete SG.
-	if err := framework.DeleteSG(sgName); err != nil {
+	// Delete Habitat.
+	if err := framework.DeleteHabitat(habitatName); err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for resources to be deleted.
-	if err := framework.WaitForResources(sgName, 0); err != nil {
+	if err := framework.WaitForResources(habitatName, 0); err != nil {
 		t.Fatal(err)
 	}
 
 	// Check if all the resources the operator creates are deleted.
 	// We do not care about secrets being deleted, as the user needs to delete those manually.
-	d, err := framework.KubeClient.AppsV1beta1().Deployments(utils.TestNs).Get(sgName, metav1.GetOptions{})
+	d, err := framework.KubeClient.AppsV1beta1().Deployments(utils.TestNs).Get(habitatName, metav1.GetOptions{})
 	if err == nil && d != nil {
 		t.Fatal("Deployment was not deleted.")
 	}
 
-	// The CM with the peer IP should still be alive, despite the SG being deleted as it was created outside of the scope of a SG.
+	// The CM with the peer IP should still be alive, despite the Habitat being deleted as it was created outside of the scope of a Habitat.
 	_, err = framework.KubeClient.CoreV1().ConfigMaps(utils.TestNs).Get(configMapName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -265,39 +265,39 @@ func TestServiceGroupDelete(t *testing.T) {
 
 // TestBind tests that the operator correctly created two Habitat Services and bound them together.
 func TestBind(t *testing.T) {
-	// Create two SG to test binding between them.
-	sgGoName := "test-bind-go"
+	// Create two Habitat to test binding between them.
+	habitatGoName := "test-bind-go"
 	bindName := "db"
-	sgGo := utils.NewStandaloneSG(sgGoName, "foobar", "kinvolk/bindgo-hab:test")
-	utils.AddBindToSG(sgGo, bindName, "postgresql")
+	habitatGo := utils.NewStandaloneHabitat(habitatGoName, "foobar", "kinvolk/bindgo-hab:test")
+	utils.AddBindToHabitat(habitatGo, bindName, "postgresql")
 
-	if err := framework.CreateSG(sgGo); err != nil {
+	if err := framework.CreateHabitat(habitatGo); err != nil {
 		t.Fatal(err)
 	}
 
-	sgDBName := "test-bind-db"
-	sgDB := utils.NewStandaloneSG(sgDBName, "foobar", "kinvolk/postgresql-hab:test")
+	habitatDBName := "test-bind-db"
+	habitatDB := utils.NewStandaloneHabitat(habitatDBName, "foobar", "kinvolk/postgresql-hab:test")
 
-	if err := framework.CreateSG(sgDB); err != nil {
+	if err := framework.CreateHabitat(habitatDB); err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for resources to be ready.
-	if err := framework.WaitForResources(sgGoName, 1); err != nil {
+	if err := framework.WaitForResources(habitatGoName, 1); err != nil {
 		t.Fatal(err)
 	}
-	if err := framework.WaitForResources(sgDBName, 1); err != nil {
+	if err := framework.WaitForResources(habitatDBName, 1); err != nil {
 		t.Fatal(err)
 	}
 
 	// Create Kubernetes Service to expose port.
 	service := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: sgGoName,
+			Name: habitatGoName,
 		},
 		Spec: apiv1.ServiceSpec{
 			Selector: map[string]string{
-				crv1.ServiceGroupLabel: sgGoName,
+				crv1.HabitatNameLabel: habitatGoName,
 			},
 			Type: "NodePort",
 			Ports: []apiv1.ServicePort{
@@ -317,7 +317,7 @@ func TestBind(t *testing.T) {
 	}
 
 	// Wait until endpoints are ready.
-	if err := framework.WaitForEndpoints(sgGoName); err != nil {
+	if err := framework.WaitForEndpoints(habitatGoName); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(waitForPorts)
@@ -349,7 +349,7 @@ func TestBind(t *testing.T) {
 	}
 
 	// Delete Service so it doesn't interfere with other tests.
-	if err := framework.DeleteService(sgGoName); err != nil {
+	if err := framework.DeleteService(habitatGoName); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This removes the amibguity between the CRD name and the habitat concept
of a service group.

The short name becomes `hab`.

I'm not 100% about this rename. For example, the full CRD name is now `habitats.habitat.sh`.

Closes #85.