### PR TITLE
Dockerfile: rename operator to habitat-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.6
 
-COPY operator /operator
+COPY habitat-operator /habitat-operator
 
-ENTRYPOINT ["/operator"]
+ENTRYPOINT ["/habitat-operator"]


### PR DESCRIPTION
This was broken after merging #87.