### PR TITLE
*: setup e2e tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: go
 
-# skip installation of dependencies since they are already in vendor/
+sudo: required
+
+# This moves Kubernetes specific config files.
+env:
+- CHANGE_MINIKUBE_NONE_USER=true
+
+# Skip installation of dependencies since they are already in vendor.
 install: true
 
 go:
@@ -9,4 +15,21 @@ go:
 git:
   depth: 1
 
-script:  make test
+before_script:
+# Download kubectl, which is a requirement for using minikube.
+- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+# Download minikube.
+- curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+- sudo minikube start --vm-driver=none --kubernetes-version=v1.7.0
+# Fix the kubectl context, as it's often stale.
+- minikube update-context
+# Hack for waiting for minikube to be ready.
+- sleep 3m
+- make TAG=testing image
+
+script:
+- make test
+- make TESTIMAGE=kinvolk/habitat-operator:testing e2e
+
+after_failure:
+- kubectl logs -lhabitat=true --tail=100

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ build:
 	go build -i github.com/kinvolk/habitat-operator/cmd/habitat-operator
 
 linux:
-	env GOOS=linux go build github.com/kinvolk/habitat-operator/cmd/habitat-operator
+	# Compile statically linked binary for linux.
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -i --ldflags="-s" -o habitat-operator github.com/kinvolk/habitat-operator/cmd/habitat-operator
 
 image: linux
 	docker build -t "$(IMAGE):$(TAG)" .

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -108,3 +108,7 @@ func (f *Framework) DeleteSG(sgName string) error {
 		Do().
 		Error()
 }
+
+func (f *Framework) DeleteService(service string) error {
+	return f.KubeClient.CoreV1().Services(apiv1.NamespaceDefault).Delete(service, &metav1.DeleteOptions{})
+}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -19,11 +19,16 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	crv1 "github.com/kinvolk/habitat-operator/pkg/habitat/apis/cr/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
+)
+
+const (
+	waitForPorts = 1 * time.Minute
 )
 
 // TestServiceGroupCreate tests service group creation.
@@ -108,6 +113,7 @@ func TestServiceGroupInitialConfig(t *testing.T) {
 	if err := framework.WaitForEndpoints(sgName); err != nil {
 		t.Fatal(err)
 	}
+	time.Sleep(waitForPorts)
 
 	// Get response from Habitat Service.
 	url := fmt.Sprintf("http://%s:30003/", framework.ExternalIP)
@@ -130,6 +136,11 @@ func TestServiceGroupInitialConfig(t *testing.T) {
 	actualMsg := string(bodyBytes)
 	if msg != actualMsg {
 		t.Fatalf("Initial Configuration failed. Msg did not match the one expected. Expected: %s got: %s", msg, actualMsg)
+	}
+
+	// Delete Service so it doesn't interfere with other tests.
+	if err := framework.DeleteService(sgName); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -176,6 +187,7 @@ func TestServiceGroupFunctioning(t *testing.T) {
 	if err := framework.WaitForEndpoints(sgName); err != nil {
 		t.Fatal(err)
 	}
+	time.Sleep(waitForPorts)
 
 	// Get response from Habitat Service.
 	url := fmt.Sprintf("http://%s:30002/", framework.ExternalIP)
@@ -199,6 +211,11 @@ func TestServiceGroupFunctioning(t *testing.T) {
 	actualMsg := string(bodyBytes)
 	if expectedMsg != actualMsg {
 		t.Fatalf("Habitat Service msg does not match one in default.toml. Expected: %s got: %s", expectedMsg, actualMsg)
+	}
+
+	// Delete Service so it doesn't interfere with other tests.
+	if err := framework.DeleteService(sgName); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This PR enables running end-to-end tests on Travis CI. This sets up Kubernetes with minikube on Travis CI, with the help of flag `--vm-driver=none`.

Closes https://github.com/kinvolk/habitat-operator/issues/76.