### PR TITLE
.travis: improve test build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_script:
 - sudo minikube start --vm-driver=none --kubernetes-version=v1.7.0
 # Fix the kubectl context, as it's often stale.
 - minikube update-context
-# Hack for waiting for minikube to be ready.
-- sleep 3m
+# Wait for Kubernetes to be up and ready.
+- JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 - make TAG=testing image
 
 script:


### PR DESCRIPTION
This PR should cuts down our test time by aprox. 2 minutes. It waits for nodes to ready, instead of just sleeping for 3 minutes.