### PR TITLE
always add peer-watch-file flag

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -445,14 +445,14 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 
 	if sg.Spec.Habitat.Topology == crv1.TopologyLeader {
 		topology = crv1.TopologyLeader
-
-		path := fmt.Sprintf("%s/%s", configMapDir, peerFilename)
-
-		habArgs = append(habArgs,
-			"--topology", topology.String(),
-			"--peer-watch-file", path,
-		)
 	}
+
+	path := fmt.Sprintf("%s/%s", configMapDir, peerFilename)
+
+	habArgs = append(habArgs,
+		"--topology", topology.String(),
+		"--peer-watch-file", path,
+	)
 
 	base := &appsv1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/habitat/controller/utils.go
+++ b/pkg/habitat/controller/utils.go
@@ -42,7 +42,7 @@ func validateCustomObject(sg crv1.ServiceGroup) error {
 	case crv1.TopologyStandalone:
 	case crv1.TopologyLeader:
 		if spec.Count < leaderFollowerTopologyMinCount {
-			return fmt.Errorf("too few instances: %s", spec.Count)
+			return fmt.Errorf("too few instances: %d, leader-follower topology requires at least %d", spec.Count, leaderFollowerTopologyMinCount)
 		}
 	default:
 		return fmt.Errorf("unkown topology: %s", spec.Habitat.Topology)


### PR DESCRIPTION
So far we were only passing the flag when we have `leader` topology. As agreed in https://github.com/kinvolk/habitat-operator/issues/49#issuecomment-325930580, we need to pass this even for standalone topologies.

As for the other change, I came across this error while working on the `--bind` and needed some time to figure out what was wrong as it only stated `too few instances`. This also fixes the formatting, as  `spec.Count` is a number.