### PR TITLE
add support for bind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ clean-test:
 	kubectl delete sg mytutorialapp
 	kubectl delete sg test-service-group
 	kubectl delete sg test-standalone
+	kubectl delete sg test-bind-go
+	kubectl delete sg test-bind-db
 	kubectl delete crd servicegroups.habitat.sh
 	kubectl delete pod habitat-operator
 	kubectl delete secret mytutorialapp
-	kubectl delete service mytutorialapp
-	kubectl delete service test-service-group
 
 .PHONY: build test linux image e2e clean-test

--- a/examples/bind/README.md
+++ b/examples/bind/README.md
@@ -1,0 +1,13 @@
+# Runtime binding
+
+This demonstrates how to run two Habitat Services with a [binding](https://www.habitat.sh/docs/run-packages-binding/) between them.
+
+After the Habitat Operator is up and running, execute the following command from the root of this repository:
+
+```
+kubectl create -f examples/bind/service_group.yml
+```
+
+This will deploy two `ServiceGroup`s, a simple HTTP server written in Go that will be bound to a PostgreSQL database. The Go server will display the port number the database listens on.
+
+When running on minikube, it can be accessed under port `5555` of the minikube VM. `minikube ip` can be used to retrieve the IP.

--- a/examples/bind/service_group.yml
+++ b/examples/bind/service_group.yml
@@ -1,0 +1,40 @@
+apiVersion: habitat.sh/v1
+kind: ServiceGroup
+metadata:
+  name: db
+spec:
+  image: kinvolk/postgresql-hab
+  count: 1
+  habitat:
+    topology: standalone
+---
+apiVersion: habitat.sh/v1
+kind: ServiceGroup
+metadata:
+  name: go
+spec:
+  image: kinvolk/bindgo-hab
+  count: 1
+  habitat:
+    topology: standalone
+    bind:
+      # Name is the name of the bind specified in the Habitat configuration files.
+      - name: db
+        # Service is the name of the service this bind refers to.
+        service: postgresql
+        # Group is the group of the service this bind refers to.
+        group: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: go-service
+spec:
+  selector:
+    service-group: go
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: 30001
+    port: 5555
+    protocol: TCP

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -62,6 +62,18 @@ type Habitat struct {
 	// The name of the secret that contains the ring key.
 	// Optional.
 	RingSecretName string `json:"ringSecretName,omitempty"`
+	// Bind is when one service connects to another forming a producer/consumer relationship.
+	// Optional.
+	Bind []Bind `json:"bind,omitempty"`
+}
+
+type Bind struct {
+	// Name is the name of the bind specified in the Habitat configuration files.
+	Name string `json:"name"`
+	// Service is the name of the service this bind refers to.
+	Service string `json:"service"`
+	// Group is the group of the service this bind refers to.
+	Group string `json:"group"`
 }
 
 type Topology string

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -455,6 +455,15 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 		"--peer-watch-file", path,
 	)
 
+	// Runtime binding.
+	// One Service connects to another forming a producer/consumer relationship.
+	for _, bind := range sg.Spec.Habitat.Bind {
+		// Pass --bind flag.
+		bindArg := fmt.Sprintf("%s:%s.%s", bind.Name, bind.Service, bind.Group)
+		habArgs = append(habArgs,
+			"--bind", bindArg)
+	}
+
 	base := &appsv1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: sg.Name,

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"time"
 
@@ -660,12 +661,12 @@ func (hc *HabitatController) syncServiceGroup(key string) error {
 }
 
 func (hc *HabitatController) serviceGroupNeedsUpdate(oldSG, newSG *crv1.ServiceGroup) bool {
-	if oldSG.Spec != newSG.Spec {
+	if reflect.DeepEqual(oldSG.Spec, newSG.Spec) {
 		level.Debug(hc.logger).Log("msg", "Update ignored as it didn't change ServiceGroup spec", "sg", newSG)
-		return true
+		return false
 	}
 
-	return false
+	return true
 }
 
 func (hc *HabitatController) podNeedsUpdate(oldPod, newPod *apiv1.Pod) bool {

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
 	appsv1beta1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
@@ -204,7 +203,7 @@ func (hc *HabitatController) handleServiceGroupCreation(sg *crv1.ServiceGroup) e
 	}
 
 	// Handle creation/updating of peer IP ConfigMap.
-	if err := hc.handleConfigMap(sg, d.UID); err != nil {
+	if err := hc.handleConfigMap(sg); err != nil {
 		return err
 	}
 
@@ -242,7 +241,7 @@ func (hc *HabitatController) writeLeaderIP(cm *apiv1.ConfigMap, ip string) error
 	return nil
 }
 
-func (hc *HabitatController) handleConfigMap(sg *crv1.ServiceGroup, deploymentUID types.UID) error {
+func (hc *HabitatController) handleConfigMap(sg *crv1.ServiceGroup) error {
 	runningPods, err := hc.getRunningPods(sg.Namespace)
 	if err != nil {
 		return err
@@ -250,7 +249,7 @@ func (hc *HabitatController) handleConfigMap(sg *crv1.ServiceGroup, deploymentUI
 
 	if len(runningPods) == 0 {
 		// No running Pods, create an empty ConfigMap.
-		newCM := newConfigMap(sg.Name, deploymentUID, "")
+		newCM := newConfigMap(sg.Name, "")
 
 		cm, err := hc.config.KubernetesClientset.CoreV1().ConfigMaps(sg.Namespace).Create(newCM)
 		if err != nil {
@@ -279,7 +278,7 @@ func (hc *HabitatController) handleConfigMap(sg *crv1.ServiceGroup, deploymentUI
 	// There are running Pods, add the IP of one of them to the ConfigMap.
 	leaderIP := runningPods[0].Status.PodIP
 
-	newCM := newConfigMap(sg.Name, deploymentUID, leaderIP)
+	newCM := newConfigMap(sg.Name, leaderIP)
 
 	cm, err := hc.config.KubernetesClientset.CoreV1Client.ConfigMaps(sg.Namespace).Create(newCM)
 	if err != nil {
@@ -705,7 +704,7 @@ func (hc *HabitatController) getServiceGroupFromPod(pod *apiv1.Pod) (*crv1.Servi
 	return sg, nil
 }
 
-func newConfigMap(sgName string, parentUID types.UID, ip string) *apiv1.ConfigMap {
+func newConfigMap(sgName string, ip string) *apiv1.ConfigMap {
 	return &apiv1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: configMapName,

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -27,13 +27,13 @@ import (
 )
 
 // NewStandaloneSG returns a new Standalone ServiceGroup.
-func (f *Framework) NewStandaloneSG(sgName, group string, secret bool) *crv1.ServiceGroup {
-	sg := crv1.ServiceGroup{
+func NewStandaloneSG(sgName, group, image string) *crv1.ServiceGroup {
+	return &crv1.ServiceGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: sgName,
 		},
 		Spec: crv1.ServiceGroupSpec{
-			Image: "kinvolk/nodejs-hab",
+			Image: image,
 			Count: 1,
 			Habitat: crv1.Habitat{
 				Group:    group,
@@ -41,11 +41,20 @@ func (f *Framework) NewStandaloneSG(sgName, group string, secret bool) *crv1.Ser
 			},
 		},
 	}
+}
 
-	if secret {
-		sg.Spec.Habitat.Config = sgName
-	}
-	return &sg
+// AddConfigToSG adds config fields to the ServiceGroup.
+func AddConfigToSG(sg *crv1.ServiceGroup) {
+	sg.Spec.Habitat.Config = sg.ObjectMeta.Name
+}
+
+// AddBindToSG appends bind fields to the ServiceGroup.
+func AddBindToSG(sg *crv1.ServiceGroup, bindName, bindService string) {
+	sg.Spec.Habitat.Bind = append(sg.Spec.Habitat.Bind, crv1.Bind{
+		Name:    bindName,
+		Service: bindService,
+		Group:   sg.Spec.Habitat.Group,
+	})
 }
 
 // CreateSG creates a ServiceGroup.

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	crv1 "github.com/kinvolk/habitat-operator/pkg/habitat/apis/cr/v1"
+	utils "github.com/kinvolk/habitat-operator/test/e2e/framework"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
@@ -30,12 +31,14 @@ import (
 const (
 	waitForPorts  = 1 * time.Minute
 	configMapName = "peer-watch-file"
+
+	nodejsImage = "kinvolk/nodejs-hab:test"
 )
 
 // TestServiceGroupCreate tests service group creation.
 func TestServiceGroupCreate(t *testing.T) {
 	sgName := "test-standalone"
-	sg := framework.NewStandaloneSG(sgName, "foobar", false)
+	sg := utils.NewStandaloneSG(sgName, "foobar", nodejsImage)
 
 	if err := framework.CreateSG(sg); err != nil {
 		t.Fatal(err)
@@ -73,7 +76,8 @@ func TestServiceGroupInitialConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sg := framework.NewStandaloneSG(sgName, "foobar", true)
+	sg := utils.NewStandaloneSG(sgName, "foobar", nodejsImage)
+	utils.AddConfigToSG(sg)
 
 	if err := framework.CreateSG(sg); err != nil {
 		t.Fatal(err)
@@ -148,7 +152,7 @@ func TestServiceGroupInitialConfig(t *testing.T) {
 // TestServiceGroupFunctioning tests that operator deploys a habitat service and that it has started.
 func TestServiceGroupFunctioning(t *testing.T) {
 	sgName := "test-service-group"
-	sg := framework.NewStandaloneSG(sgName, "foobar", false)
+	sg := utils.NewStandaloneSG(sgName, "foobar", nodejsImage)
 
 	if err := framework.CreateSG(sg); err != nil {
 		t.Fatal(err)
@@ -223,7 +227,7 @@ func TestServiceGroupFunctioning(t *testing.T) {
 // TestServiceGroupDelete tests Service Group deletion.
 func TestServiceGroupDelete(t *testing.T) {
 	sgName := "test-deletion"
-	sg := framework.NewStandaloneSG(sgName, "foobar", false)
+	sg := utils.NewStandaloneSG(sgName, "foobar", nodejsImage)
 
 	if err := framework.CreateSG(sg); err != nil {
 		t.Fatal(err)

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -258,6 +259,97 @@ func TestServiceGroupDelete(t *testing.T) {
 	// The CM with the peer IP should still be alive, despite the SG being deleted as it was created outside of the scope of a SG.
 	_, err = framework.KubeClient.CoreV1().ConfigMaps(apiv1.NamespaceDefault).Get(configMapName, metav1.GetOptions{})
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestBind tests that the operator correctly created two Habitat Services and bound them together.
+func TestBind(t *testing.T) {
+	// Create two SG to test binding between them.
+	sgGoName := "test-bind-go"
+	bindName := "db"
+	sgGo := utils.NewStandaloneSG(sgGoName, "foobar", "kinvolk/bindgo-hab:test")
+	utils.AddBindToSG(sgGo, bindName, "postgresql")
+
+	if err := framework.CreateSG(sgGo); err != nil {
+		t.Fatal(err)
+	}
+
+	sgDBName := "test-bind-db"
+	sgDB := utils.NewStandaloneSG(sgDBName, "foobar", "kinvolk/postgresql-hab:test")
+
+	if err := framework.CreateSG(sgDB); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for resources to be ready.
+	if err := framework.WaitForResources(sgGoName, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := framework.WaitForResources(sgDBName, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Kubernetes Service to expose port.
+	service := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sgGoName,
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{
+				crv1.ServiceGroupLabel: sgGoName,
+			},
+			Type: "NodePort",
+			Ports: []apiv1.ServicePort{
+				apiv1.ServicePort{
+					Name:     "go",
+					NodePort: 30005,
+					Port:     5555,
+				},
+			},
+		},
+	}
+
+	// Create Service.
+	_, err := framework.KubeClient.CoreV1().Services(apiv1.NamespaceDefault).Create(service)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until endpoints are ready.
+	if err := framework.WaitForEndpoints(sgGoName); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(waitForPorts)
+
+	// Get response from Habitat Service.
+	url := fmt.Sprintf("http://%s:30005/", framework.ExternalIP)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("Habitat Service did not start correctly.")
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This msg is set in the config of the kinvolk/bindgo-hab Go Habitat Service.
+	expectedMsg := "hello from port: 5432"
+	actualMsg := string(bodyBytes)
+	// actualMsg can contain whitespace and newlines or different formatting,
+	// the only thing we need to check is it contains the expectedMsg.
+	if !strings.Contains(actualMsg, expectedMsg) {
+		t.Fatalf("Habitat Service msg does not match one in default.toml. Expected: *%s* got: *%s*", expectedMsg, actualMsg)
+	}
+
+	// Delete Service so it doesn't interfere with other tests.
+	if err := framework.DeleteService(sgGoName); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This PR introduces [binding](https://www.habitat.sh/docs/run-packages-binding/). Bind is when one service connects to another forming a producer/consumer relationship. The image taken is a simple [Go server](https://github.com/kinvolk/habitat-server-go-example) that displays the port the bound database listens on.

I also introduced tags for the images we use in tests, this should prevent any accidental modifying.

This closes https://github.com/kinvolk/habitat-operator/issues/53