### PR TITLE
test: use testing namespace in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,6 @@ e2e:
 	go test -v ./test/e2e/ --image "$(TESTIMAGE)" --kubeconfig ~/.kube/config --ip "$(EIP)"
 
 clean-test:
-	kubectl delete sg mytutorialapp
-	kubectl delete sg test-service-group
-	kubectl delete sg test-standalone
-	kubectl delete sg test-bind-go
-	kubectl delete sg test-bind-db
-	kubectl delete crd servicegroups.habitat.sh
-	kubectl delete pod habitat-operator
-	kubectl delete secret mytutorialapp
+	kubectl delete namespace testing
 
 .PHONY: build test linux image e2e clean-test

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -28,6 +28,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	TestNs = "testing"
+)
+
 type Framework struct {
 	Image      string
 	KubeClient kubernetes.Interface
@@ -59,6 +63,16 @@ func Setup(image, kubeconfig, externalIP string) (*Framework, error) {
 		ExternalIP: externalIP,
 	}
 
+	// Create a new Kubernetes namespace for testing purposes.
+	_, err = f.KubeClient.CoreV1().Namespaces().Create(&apiv1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: TestNs,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	if err = f.setupOperator(); err != nil {
 		return nil, err
 	}
@@ -86,7 +100,7 @@ func (f *Framework) setupOperator() error {
 	}
 
 	// Create pod with the Habitat operator image.
-	_, err := f.KubeClient.CoreV1().Pods(apiv1.NamespaceDefault).Create(pod)
+	_, err := f.KubeClient.CoreV1().Pods(TestNs).Create(pod)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -19,7 +19,6 @@ import (
 
 	crv1 "github.com/kinvolk/habitat-operator/pkg/habitat/apis/cr/v1"
 
-	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -60,7 +59,7 @@ func AddBindToSG(sg *crv1.ServiceGroup, bindName, bindService string) {
 // CreateSG creates a ServiceGroup.
 func (f *Framework) CreateSG(sg *crv1.ServiceGroup) error {
 	return f.Client.Post().
-		Namespace(apiv1.NamespaceDefault).
+		Namespace(TestNs).
 		Resource(crv1.ServiceGroupResourcePlural).
 		Body(sg).
 		Do().
@@ -80,7 +79,7 @@ func (f *Framework) WaitForResources(sgName string, numPods int) error {
 			crv1.ServiceGroupLabel: sgName,
 		})
 
-		pods, err := f.KubeClient.CoreV1().Pods(apiv1.NamespaceDefault).List(metav1.ListOptions{FieldSelector: fs.String(), LabelSelector: ls.String()})
+		pods, err := f.KubeClient.CoreV1().Pods(TestNs).List(metav1.ListOptions{FieldSelector: fs.String(), LabelSelector: ls.String()})
 		if err != nil {
 			return false, err
 		}
@@ -95,7 +94,7 @@ func (f *Framework) WaitForResources(sgName string, numPods int) error {
 
 func (f *Framework) WaitForEndpoints(sgName string) error {
 	return wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
-		ep, err := f.KubeClient.CoreV1().Endpoints(apiv1.NamespaceDefault).Get(sgName, metav1.GetOptions{})
+		ep, err := f.KubeClient.CoreV1().Endpoints(TestNs).Get(sgName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -111,7 +110,7 @@ func (f *Framework) WaitForEndpoints(sgName string) error {
 // DeleteSG deletes a ServiceGroup as a user would.
 func (f *Framework) DeleteSG(sgName string) error {
 	return f.Client.Delete().
-		Namespace(apiv1.NamespaceDefault).
+		Namespace(TestNs).
 		Resource(crv1.ServiceGroupResourcePlural).
 		Name(sgName).
 		Do().
@@ -119,5 +118,5 @@ func (f *Framework) DeleteSG(sgName string) error {
 }
 
 func (f *Framework) DeleteService(service string) error {
-	return f.KubeClient.CoreV1().Services(apiv1.NamespaceDefault).Delete(service, &metav1.DeleteOptions{})
+	return f.KubeClient.CoreV1().Services(TestNs).Delete(service, &metav1.DeleteOptions{})
 }

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -50,7 +50,7 @@ func TestServiceGroupCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := framework.KubeClient.CoreV1().ConfigMaps(apiv1.NamespaceDefault).Get(configMapName, metav1.GetOptions{})
+	_, err := framework.KubeClient.CoreV1().ConfigMaps(utils.TestNs).Get(configMapName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestServiceGroupInitialConfig(t *testing.T) {
 		},
 	}
 
-	_, err := framework.KubeClient.CoreV1().Secrets(apiv1.NamespaceDefault).Create(secret)
+	_, err := framework.KubeClient.CoreV1().Secrets(utils.TestNs).Create(secret)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestServiceGroupInitialConfig(t *testing.T) {
 	}
 
 	// Create Service.
-	_, err = framework.KubeClient.CoreV1().Services(apiv1.NamespaceDefault).Create(service)
+	_, err = framework.KubeClient.CoreV1().Services(utils.TestNs).Create(service)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +184,7 @@ func TestServiceGroupFunctioning(t *testing.T) {
 		},
 	}
 	// Create Service.
-	_, err := framework.KubeClient.CoreV1().Services(apiv1.NamespaceDefault).Create(service)
+	_, err := framework.KubeClient.CoreV1().Services(utils.TestNs).Create(service)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,13 +251,13 @@ func TestServiceGroupDelete(t *testing.T) {
 
 	// Check if all the resources the operator creates are deleted.
 	// We do not care about secrets being deleted, as the user needs to delete those manually.
-	d, err := framework.KubeClient.AppsV1beta1().Deployments(apiv1.NamespaceDefault).Get(sgName, metav1.GetOptions{})
+	d, err := framework.KubeClient.AppsV1beta1().Deployments(utils.TestNs).Get(sgName, metav1.GetOptions{})
 	if err == nil && d != nil {
 		t.Fatal("Deployment was not deleted.")
 	}
 
 	// The CM with the peer IP should still be alive, despite the SG being deleted as it was created outside of the scope of a SG.
-	_, err = framework.KubeClient.CoreV1().ConfigMaps(apiv1.NamespaceDefault).Get(configMapName, metav1.GetOptions{})
+	_, err = framework.KubeClient.CoreV1().ConfigMaps(utils.TestNs).Get(configMapName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +311,7 @@ func TestBind(t *testing.T) {
 	}
 
 	// Create Service.
-	_, err := framework.KubeClient.CoreV1().Services(apiv1.NamespaceDefault).Create(service)
+	_, err := framework.KubeClient.CoreV1().Services(utils.TestNs).Create(service)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
All the resources in the tests are created in the "testing" Kubernetes namespace.
This makes it easier to run the tests locally as they do not interfere with any existing resources. Also helps with the test cleanup.

This closes https://github.com/kinvolk/habitat-operator/issues/96.