### PR TITLE
*: rename config field

### DIFF
--- a/examples/nodejs/service_group.yml
+++ b/examples/nodejs/service_group.yml
@@ -21,7 +21,7 @@ spec:
     topology: standalone
     group: nodejs
     # Create Secret with the initial configuration you want.
-    config: user-toml-secret
+    configSecretName: user-toml-secret
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -55,10 +55,10 @@ type Habitat struct {
 	Group string `json:"group"`
 	// Topology is the value of the --topology flag for the hab client.
 	Topology `json:"topology"`
-	// Config is the name of the Secret that the user has previously created.
+	// ConfigSecretName is the name of the Secret containing the config the user has previously created.
 	// The file with this name is mounted inside of the pod. Habitat will
 	// use it for initial configuration of the service.
-	Config string `json:"config"`
+	ConfigSecretName string `json:"config"`
 	// The name of the secret that contains the ring key.
 	// Optional.
 	RingSecretName string `json:"ringSecretName,omitempty"`

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -518,9 +518,9 @@ func (hc *HabitatController) newDeployment(sg *crv1.ServiceGroup) (*appsv1beta1.
 	}
 
 	// If we have a secret name present we should mount that secret.
-	if sg.Spec.Habitat.Config != "" {
+	if sg.Spec.Habitat.ConfigSecretName != "" {
 		// Let's make sure our secret is there before mounting it.
-		secret, err := hc.config.KubernetesClientset.CoreV1().Secrets(sg.Namespace).Get(sg.Spec.Habitat.Config, metav1.GetOptions{})
+		secret, err := hc.config.KubernetesClientset.CoreV1().Secrets(sg.Namespace).Get(sg.Spec.Habitat.ConfigSecretName, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -42,9 +42,9 @@ func NewStandaloneSG(sgName, group, image string) *crv1.ServiceGroup {
 	}
 }
 
-// AddConfigToSG adds config fields to the ServiceGroup.
+// AddConfigToSG adds a ConfigSecretName field to the ServiceGroup.
 func AddConfigToSG(sg *crv1.ServiceGroup) {
-	sg.Spec.Habitat.Config = sg.ObjectMeta.Name
+	sg.Spec.Habitat.ConfigSecretName = sg.ObjectMeta.Name
 }
 
 // AddBindToSG appends bind fields to the ServiceGroup.


### PR DESCRIPTION
Adjust config name to `ConfigSecretName` to be more descriptive.

Closes issue https://github.com/kinvolk/habitat-operator/issues/95.