### PR TITLE
Fix user.toml example

### DIFF
--- a/examples/config/README.md
+++ b/examples/config/README.md
@@ -7,7 +7,7 @@ NOTE: Adding secret configuration to the `default.toml` is discouraged, as it wi
 
 After the Habitat operator is up and running, execute the following command from the root of this repository:
 
-`kubectl create -f /examples/nodejs`
+`kubectl create -f examples/config/service_group.yml`
 
 This will create a [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/) with the configurations and a simple Node.js application that will display a msg. When running on minikube, it can be accessed under port `30001` of the minikube VM. `minikube ip` can be used to retrieve the IP.
 Initially our app is configured to display the msg `"Hello world."`. Because we override this with the Secret we just created, our app will instead display `Hello from our Habitat-Operator!`.

--- a/examples/config/service_group.yml
+++ b/examples/config/service_group.yml
@@ -32,10 +32,12 @@ spec:
     service-group: mytutorialapp
   type: NodePort
   ports:
+  # This endpoint displays the message from the secret
   - name: web
     nodePort: 30001
     port: 5555
     protocol: TCP
+  # This endpoint exposes the Habitat supervisor API
   - name: http-gateway
     nodePort : 32767
     port: 9631

--- a/pkg/habitat/apis/cr/v1/types.go
+++ b/pkg/habitat/apis/cr/v1/types.go
@@ -58,7 +58,7 @@ type Habitat struct {
 	// ConfigSecretName is the name of the Secret containing the config the user has previously created.
 	// The file with this name is mounted inside of the pod. Habitat will
 	// use it for initial configuration of the service.
-	ConfigSecretName string `json:"config"`
+	ConfigSecretName string `json:"configSecretName,omitempty"`
 	// The name of the secret that contains the ring key.
 	// Optional.
 	RingSecretName string `json:"ringSecretName,omitempty"`


### PR DESCRIPTION
The serialization was incorrect, so the secret was never mounted.

Also adds `omitempty` since it's an optional key.