### PR TITLE
CHANGELOG: add release notes for 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Habitat operator CHANGELOG
+
+## 0.1.0/2017-10-9
+
+First release of Habitat operator. Highlight of features:
+
+* [FEATURE] Support for creating/managing Habitat Services
+* [FEATURE] Support for different Habitat topologies
+* [FEATURE] Support for bind feature
+* [FEATURE] Support for initial configuration
+* [FEATURE] Support for encrypted ring communication
+


### PR DESCRIPTION
This PR introduces a `CHANGELOG` file. Also added the notes that went to the `0.1.0` release.

