### PR TITLE
examples: add bind-config example

### DIFF
--- a/examples/bind-config/README.md
+++ b/examples/bind-config/README.md
@@ -1,0 +1,16 @@
+# Runtime binding + initial configuration
+
+This demonstrates how to run two Habitat Services with a [binding](https://www.habitat.sh/docs/run-packages-binding/) between them, with initial configuration used to override the port of the PostgreSQL Habitat service. It also displays how different fields in the manifest file can be combined.
+
+## Workflow
+
+After the Habitat operator is up and running, execute the following command from the root of this repository:
+
+```
+kubectl create -f examples/bind+config/service_group.yml
+```
+
+This will deploy two `ServiceGroup`s, a simple HTTP server written in Go that will be bound to a PostgreSQL database. The Go server will display the database port number that was overriden by the initial configuration.
+
+When running on minikube, it can be accessed under port `5555` of the minikube VM. `minikube ip` can be used to retrieve the IP.
+

--- a/examples/bind-config/habitat.yml
+++ b/examples/bind-config/habitat.yml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: user-toml-secret
+type: Opaque
+data:
+  # Each item needs to be encoded in base64, as Kubernetes expects that encoding.
+  # Plain text content of the secret: "port = 4444"
+  # This overrides the port set in the postgresql Habitat service.
+  user.toml: cG9ydCA9IDQ0NDQ=
+---
+apiVersion: habitat.sh/v1
+kind: Habitat 
+metadata:
+  # Name must match the Habitat service name.
+  name: postgresql
+spec:
+  image: kinvolk/postgresql-hab
+  count: 1
+  service:
+    # Name of the secret.
+    # This is mounted inside of the pod as a user.toml file.
+    configSecretName: user-toml-secret
+    topology: standalone
+---
+apiVersion: habitat.sh/v1
+kind: Habitat
+metadata:
+  name: go
+spec:
+  image: kinvolk/bindgo-hab
+  count: 1
+  service:
+    topology: standalone
+    bind:
+      - name: db
+        service: postgresql
+        group: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: go-service
+spec:
+  selector:
+    habitat-name: go
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: 30001
+    port: 5555
+    protocol: TCP


### PR DESCRIPTION
Example demonstrates how different fields in the manifest file work
together.

This was added to the examples as it was used in a recorded demo.

Closes https://github.com/kinvolk/habitat-operator/issues/103.