### PR TITLE
React on events

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -442,6 +442,9 @@ func (hc *HabitatController) handleConfigMap(h *crv1.Habitat) error {
 			if err := hc.writeLeaderIP(cm, ""); err != nil {
 				return err
 			}
+
+			level.Info(hc.logger).Log("msg", "removed peer IP from ConfigMap", "name", newCM.Name)
+
 			return nil
 		}
 

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -333,10 +333,6 @@ func (hc *HabitatController) handlePodUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	if oldPod.ObjectMeta.Labels[crv1.HabitatLabel] != "true" {
-		return
-	}
-
 	newPod, ok2 := newObj.(*apiv1.Pod)
 	if !ok2 {
 		level.Error(hc.logger).Log("msg", "Failed to type assert pod", "obj", newObj)

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -844,6 +844,9 @@ func newConfigMap(ip string) *apiv1.ConfigMap {
 	return &apiv1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: configMapName,
+			Labels: map[string]string{
+				crv1.HabitatLabel: "true",
+			},
 		},
 		Data: map[string]string{
 			peerFile: ip,

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -196,7 +196,7 @@ func (hc *HabitatController) cacheConfigMap() {
 }
 
 func (hc *HabitatController) watchPods(ctx context.Context) {
-	ls := labels.SelectorFromSet(labels.Set(map[string]string{"habitat": "true"}))
+	ls := labels.SelectorFromSet(labels.Set(map[string]string{crv1.HabitatLabel: "true"}))
 
 	source := newListWatchFromClientWithLabels(
 		hc.config.KubernetesClientset.CoreV1().RESTClient(),
@@ -253,7 +253,7 @@ func (hc *HabitatController) handleDeployAdd(obj interface{}) {
 		return
 	}
 
-	if d.ObjectMeta.Labels["habitat"] == "true" {
+	if d.ObjectMeta.Labels[crv1.HabitatLabel] == "true" {
 		hc.enqueue(obj)
 	}
 }
@@ -265,7 +265,7 @@ func (hc *HabitatController) handleDeployUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	if d.ObjectMeta.Labels["habitat"] == "true" {
+	if d.ObjectMeta.Labels[crv1.HabitatLabel] == "true" {
 		hc.enqueue(newObj)
 	}
 }
@@ -277,28 +277,28 @@ func (hc *HabitatController) handleDeployDelete(obj interface{}) {
 		return
 	}
 
-	if d.ObjectMeta.Labels["habitat"] == "true" {
+	if d.ObjectMeta.Labels[crv1.HabitatLabel] == "true" {
 		hc.enqueue(obj)
 	}
 }
 
 func (hc *HabitatController) handleCMAdd(obj interface{}) {
 	cm := obj.(*apiv1.ConfigMap)
-	if cm.ObjectMeta.Labels["habitat"] == "true" {
+	if cm.ObjectMeta.Labels[crv1.HabitatLabel] == "true" {
 		hc.enqueueNs(cm.GetNamespace())
 	}
 }
 
 func (hc *HabitatController) handleCMUpdate(oldObj, newObj interface{}) {
 	cm := newObj.(*apiv1.ConfigMap)
-	if cm.ObjectMeta.Labels["habitat"] == "true" {
+	if cm.ObjectMeta.Labels[crv1.HabitatLabel] == "true" {
 		hc.enqueueNs(cm.GetNamespace())
 	}
 }
 
 func (hc *HabitatController) handleCMDelete(obj interface{}) {
 	cm := obj.(*apiv1.ConfigMap)
-	if cm.ObjectMeta.Labels["habitat"] == "true" {
+	if cm.ObjectMeta.Labels[crv1.HabitatLabel] == "true" {
 		hc.enqueueNs(cm.GetNamespace())
 	}
 }
@@ -314,7 +314,7 @@ func (hc *HabitatController) enqueueNs(ns string) {
 
 func (hc *HabitatController) handlePodAdd(obj interface{}) {
 	pod := obj.(*apiv1.Pod)
-	if pod.ObjectMeta.Labels["habitat"] == "true" {
+	if pod.ObjectMeta.Labels[crv1.HabitatLabel] == "true" {
 		h, err := hc.getHabitatFromPod(pod)
 		if err != nil {
 			if hErr, ok := err.(habitatNotFoundError); !ok {
@@ -333,7 +333,7 @@ func (hc *HabitatController) handlePodUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	if oldPod.ObjectMeta.Labels["habitat"] != "true" {
+	if oldPod.ObjectMeta.Labels[crv1.HabitatLabel] != "true" {
 		return
 	}
 
@@ -370,7 +370,7 @@ func (hc *HabitatController) handlePodDelete(obj interface{}) {
 		return
 	}
 
-	if pod.ObjectMeta.Labels["habitat"] != "true" {
+	if pod.ObjectMeta.Labels[crv1.HabitatLabel] != "true" {
 		return
 	}
 


### PR DESCRIPTION
So far we were only reacting on `Habitat` and `Pod` events. This PR adds `Deployment` and `ConfigMap` events. This PR also stores the cache. This cache will be used in the subsequent PR and it will optimise the unnecessary calls to the API. My reasons for splitting is for easier review.

Couple of points:
- In the `handleHab` function I extracted the handling into separate functions to be consistent with the other resource handlers.
- Adding enqueuing in the `handlePodAdd` improves the time the IP is written into the `peer-watch-file` CM.
- I have explored reacting to `Secrets` as well and storing them. But we do not store any information about which `Secret` belongs to which `Habitat`. Therefor we cannot enqueue the correct `Habitat` object and would need to enqueue al of the existing `Habitat`s in all namespaces, which would just slow things down.
- We do react on `ConfigMap` events even if it's one `CM` for all the `Habitat`s. We do this because if there is an add/update/delete event on the peer-watch-file `CM` we do want to reconcile again asap no matter the `Habitat`.
- As for the `Pod`s as @asymmetric already [discovered](https://github.com/kinvolk/habitat-operator/issues/65#issuecomment-324927718) we cannot use the cache to get rid of the API calls.

Closes https://github.com/kinvolk/habitat-operator/issues/66.