### PR TITLE
examples: Fix some renaming leftovers

### DIFF
--- a/examples/bind-config/README.md
+++ b/examples/bind-config/README.md
@@ -7,10 +7,9 @@ This demonstrates how to run two Habitat Services with a [binding](https://www.h
 After the Habitat operator is up and running, execute the following command from the root of this repository:
 
 ```
-kubectl create -f examples/bind+config/service_group.yml
+kubectl create -f examples/bind-config/habitat.yml
 ```
 
-This will deploy two `ServiceGroup`s, a simple HTTP server written in Go that will be bound to a PostgreSQL database. The Go server will display the database port number that was overriden by the initial configuration.
+This will deploy two `Habitat`s, a simple HTTP server written in Go that will be bound to a PostgreSQL database. The Go server will display the database port number that was overriden by the initial configuration.
 
 When running on minikube, it can be accessed under port `5555` of the minikube VM. `minikube ip` can be used to retrieve the IP.
-

--- a/examples/leader/README.md
+++ b/examples/leader/README.md
@@ -11,4 +11,3 @@ Simply run:
 This will deploy 3 instances of consul Habitat service.
 
 Note: Whenever creating a `leader` topology specify instance `count` of 3 or more and would be best if the number is odd, this is so the election can take place.
-


### PR DESCRIPTION
Somehow the ServiceGroup/service_group thing survived in one
example. Fix it and correct the typo in the directory name at the same
time.