### PR TITLE
examples: Change webserver port to 30001 in README

### DIFF
--- a/examples/bind-config/README.md
+++ b/examples/bind-config/README.md
@@ -12,4 +12,4 @@ kubectl create -f examples/bind-config/habitat.yml
 
 This will deploy two `Habitat`s, a simple HTTP server written in Go that will be bound to a PostgreSQL database. The Go server will display the database port number that was overriden by the initial configuration.
 
-When running on minikube, it can be accessed under port `5555` of the minikube VM. `minikube ip` can be used to retrieve the IP.
+When running on minikube, it can be accessed under port `30001` of the minikube VM. `minikube ip` can be used to retrieve the IP.

--- a/examples/bind/README.md
+++ b/examples/bind/README.md
@@ -12,4 +12,4 @@ kubectl create -f examples/bind/habitat.yml
 
 This will deploy two `Habitat`s, a simple HTTP server written in Go that will be bound to a PostgreSQL database. The Go server will display the port number the database listens on.
 
-When running on minikube, it can be accessed under port `5555` of the minikube VM. `minikube ip` can be used to retrieve the IP.
+When running on minikube, it can be accessed under port `30001` of the minikube VM. `minikube ip` can be used to retrieve the IP.


### PR DESCRIPTION
5555 is the port on the Pod, whereas 30001 is the one accessible on the
Node.

Signed-off-by: Lorenzo Manacorda <lorenzo@kinvolk.io>