### PR TITLE
*: Add example deployment manifest for operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ The name of the generated docker image can be changed with an `IMAGE` variable, 
 
 Habitat operator images are located [here](https://hub.docker.com/r/kinvolk/habitat-operator/), they are tagged with the release version.
 
+#### Deploying Habitat operator
+
+To deploy the operator inside the Kubernetes cluster use the Deployment manifest file located under the examples directory:
+
+    kubectl create -f examples/habitat-operator-deployment.yml
+
 ### Deploying an example
 
 To create an example service run:

--- a/examples/habitat-operator-deployment.yml
+++ b/examples/habitat-operator-deployment.yml
@@ -1,0 +1,14 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: habitat-operator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: habitat-operator
+    spec:
+      containers:
+      - name: habitat-operator
+        image: kinvolk/habitat-operator:v0.1.0


### PR DESCRIPTION
To ensure that the appropriate number of replicas of the Habitat
operator are always running, this introduces a Deployment rather than a
single static Pod.