### PR TITLE
examples: add RBAC manifest files example

### DIFF
--- a/examples/rbac/README.md
+++ b/examples/rbac/README.md
@@ -1,0 +1,14 @@
+# RBAC Habitat example
+
+[RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) stands for role-based access control, and in Kubernetes it's aimed at limiting the permissions within the cluster. The Habitat operator requires some access within the cluster, for example for creating and managing the `CRD` and all the other necessary resources. This is where the following example comes in. If the API server is started with the `--authorization-mode=RBAC` flag, then the following roles must be created for the Habitat operator to function properly.
+
+## Workflow
+
+Before deploying the Habitat operator inside your cluster the following roles must be created:
+
+    kubectl apply -f examples/rbac/rbac.yml
+
+Once those roles were successfully created the Habitat operator can be deployed in the cluster:
+
+    kubectl apply -f examples/rbac/habitat.yml
+

--- a/examples/rbac/habitat.yml
+++ b/examples/rbac/habitat.yml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: habitat-operator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: habitat-operator
+    spec:
+      containers:
+      - name: habitat-operator
+        image: kinvolk/habitat-operator:v0.1.0
+      serviceAccountName: habitat-operator

--- a/examples/rbac/rbac.yml
+++ b/examples/rbac/rbac.yml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: habitat-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: habitat-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: habitat-operator
+subjects:
+- kind: ServiceAccount
+  name: habitat-operator
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: habitat-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups:
+  - habitat.sh
+  resources:
+  - habitats
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["get"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list"]


### PR DESCRIPTION
This PR adds an example for how to deploy Habitat operator and the roles for RBAC enabled Kubernetes clusters.

Closes https://github.com/kinvolk/habitat-operator/issues/99.