### PR TITLE
Fix Habitat removal

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -741,7 +741,7 @@ func (hc *HabitatController) newDeployment(h *crv1.Habitat) (*appsv1beta1.Deploy
 func (hc *HabitatController) enqueue(hab *crv1.Habitat) {
 	k, err := cache.DeletionHandlingMetaNamespaceKeyFunc(hab)
 	if err != nil {
-		level.Error(hc.logger).Log("msg", "Object key could not be retrieved", "object", hab)
+		level.Error(hc.logger).Log("msg", "Habitat object key could not be retrieved", "object", hab)
 		return
 	}
 

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -718,10 +718,10 @@ func (hc *HabitatController) newDeployment(h *crv1.Habitat) (*appsv1beta1.Deploy
 	return base, nil
 }
 
-func (hc *HabitatController) enqueue(obj interface{}) {
-	k, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+func (hc *HabitatController) enqueue(hab *crv1.Habitat) {
+	k, err := cache.DeletionHandlingMetaNamespaceKeyFunc(hab)
 	if err != nil {
-		level.Error(hc.logger).Log("msg", "Object key could not be retrieved", "object", obj)
+		level.Error(hc.logger).Log("msg", "Object key could not be retrieved", "object", hab)
 		return
 	}
 

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -333,7 +333,7 @@ func (hc *HabitatController) handlePodAdd(obj interface{}) {
 		return
 	}
 	if isHabitatObject(&pod.ObjectMeta) {
-		h, err := hc.getHabitatFromPod(pod)
+		h, err := hc.getHabitatFromResource(pod)
 		if err != nil {
 			if hErr, ok := err.(habitatNotFoundError); !ok {
 				level.Error(hc.logger).Log("msg", hErr)
@@ -361,7 +361,7 @@ func (hc *HabitatController) handlePodUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	h, err := hc.getHabitatFromPod(newPod)
+	h, err := hc.getHabitatFromResource(newPod)
 	if err != nil {
 		if hErr, ok := err.(habitatNotFoundError); !ok {
 			level.Error(hc.logger).Log("msg", hErr)
@@ -388,7 +388,7 @@ func (hc *HabitatController) handlePodDelete(obj interface{}) {
 		return
 	}
 
-	h, err := hc.getHabitatFromPod(pod)
+	h, err := hc.getHabitatFromResource(pod)
 	if err != nil {
 		if hErr, ok := err.(habitatNotFoundError); !ok {
 			level.Error(hc.logger).Log("msg", hErr)
@@ -848,8 +848,8 @@ func (hc *HabitatController) podNeedsUpdate(oldPod, newPod *apiv1.Pod) bool {
 	return true
 }
 
-func (hc *HabitatController) getHabitatFromPod(pod *apiv1.Pod) (*crv1.Habitat, error) {
-	key := habitatKeyFromPod(pod)
+func (hc *HabitatController) getHabitatFromResource(r metav1.Object) (*crv1.Habitat, error) {
+	key := habitatKeyFromResource(r)
 
 	obj, exists, err := hc.habInformer.GetStore().GetByKey(key)
 	if err != nil {
@@ -881,10 +881,9 @@ func newConfigMap(ip string) *apiv1.ConfigMap {
 	}
 }
 
-func habitatKeyFromPod(pod *apiv1.Pod) string {
-	hName := pod.Labels[crv1.HabitatNameLabel]
-
-	key := fmt.Sprintf("%s/%s", pod.Namespace, hName)
+func habitatKeyFromResource(r metav1.Object) string {
+	hName := r.GetLabels()[crv1.HabitatNameLabel]
+	key := fmt.Sprintf("%s/%s", r.GetNamespace(), hName)
 
 	return key
 }

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -221,7 +221,13 @@ func (hc *HabitatController) watchPods(ctx context.Context) {
 }
 
 func (hc *HabitatController) handleHabAdd(obj interface{}) {
-	hc.enqueue(obj)
+	h, ok := obj.(*crv1.Habitat)
+	if !ok {
+		level.Error(hc.logger).Log("msg", "Failed to type assert Habitat", "obj", obj)
+		return
+	}
+
+	hc.enqueue(h)
 }
 
 func (hc *HabitatController) handleHabUpdate(oldObj, newObj interface{}) {
@@ -243,7 +249,13 @@ func (hc *HabitatController) handleHabUpdate(oldObj, newObj interface{}) {
 }
 
 func (hc *HabitatController) handleHabDelete(obj interface{}) {
-	hc.enqueue(obj)
+	h, ok := obj.(*crv1.Habitat)
+	if !ok {
+		level.Error(hc.logger).Log("msg", "Failed to type assert Habitat", "obj", obj)
+		return
+	}
+
+	hc.enqueue(h)
 }
 
 func (hc *HabitatController) handleDeployAdd(obj interface{}) {


### PR DESCRIPTION
This fixes #122.

We were enqueueing Deployments as well as Habitats, but then expecting Habitats in the `enqueue` function.

Additionally, we now perform a type assertion on every handler, for consistency and safety.