### PR TITLE
*: cut 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Habitat operator CHANGELOG
+
+## [v0.2.0](https://github.com/kinvolk/habitat-operator/tree/v0.2.0) (2017-20-11)
+[Full changelog](https://github.com/kinvolk/habitat-operator/compare/v0.1.0...v0.2.0)
+
+## Features & Enhancements
+
+- React to all events involved with a Habitat object for faster and more consistent reconciliation with the desired state. [#113](https://github.com/kinvolk/habitat-operator/pull/113)
+- Update Deployment when Habitat object is updated [#124](https://github.com/kinvolk/habitat-operator/pull/124)
+
+## Bug fixes
+
+- Fix Habitat removal [#125](https://github.com/kinvolk/habitat-operator/pull/125)
+

--- a/examples/habitat-operator-deployment.yml
+++ b/examples/habitat-operator-deployment.yml
@@ -11,4 +11,4 @@ spec:
     spec:
       containers:
       - name: habitat-operator
-        image: kinvolk/habitat-operator:v0.1.0
+        image: kinvolk/habitat-operator:v0.2.0

--- a/examples/rbac/habitat.yml
+++ b/examples/rbac/habitat.yml
@@ -11,5 +11,5 @@ spec:
     spec:
       containers:
       - name: habitat-operator
-        image: kinvolk/habitat-operator:v0.1.0
+        image: kinvolk/habitat-operator:v0.2.0
       serviceAccountName: habitat-operator


### PR DESCRIPTION
This PR cuts the release: bumps the version and adds an entry for the new version in the changelog. Once merged, off of the latest commit on master a new branch called "release-0.2" and the "v0.2.0" tag is created. Both are then pushed to the upstream repository.

cc @asymmetric @nhlfr 