### PR TITLE
Wait for caches to be synced before starting worker

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -71,7 +71,7 @@ type HabitatController struct {
 
 	habInformer    cache.SharedIndexInformer
 	deployInformer cache.SharedIndexInformer
-	cMInformer     cache.SharedIndexInformer
+	cmInformer     cache.SharedIndexInformer
 }
 
 type Config struct {
@@ -114,7 +114,7 @@ func (hc *HabitatController) Run(ctx context.Context) error {
 
 	go hc.habInformer.Run(ctx.Done())
 	go hc.deployInformer.Run(ctx.Done())
-	go hc.cMInformer.Run(ctx.Done())
+	go hc.cmInformer.Run(ctx.Done())
 
 	// Start the synchronous queue consumer.
 	go hc.worker()
@@ -181,14 +181,14 @@ func (hc *HabitatController) cacheConfigMap() {
 		apiv1.NamespaceAll,
 		ls)
 
-	hc.cMInformer = cache.NewSharedIndexInformer(
+	hc.cmInformer = cache.NewSharedIndexInformer(
 		source,
 		&apiv1.ConfigMap{},
 		resyncPeriod,
 		cache.Indexers{},
 	)
 
-	hc.cMInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	hc.cmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    hc.handleCMAdd,
 		UpdateFunc: hc.handleCMUpdate,
 		DeleteFunc: hc.handleCMDelete,


### PR DESCRIPTION
As [recommended (point 6)](https://github.com/kubernetes/community/blob/master/contributors/devel/controllers.md), we should wait until the caches have been synced before we start workers.

In that text though, it recommends only checking that **secondary** caches are synced, but looking at how Kubernetes [controllers](https://github.com/kubernetes/kubernetes/blob/38e33513126e2090b578531b7c3919348bf6b167/pkg/controller/replicaset/replica_set.go#L186) [themselves](https://github.com/kubernetes/kubernetes/blob/38e33513126e2090b578531b7c3919348bf6b167/pkg/controller/deployment/deployment_controller.go#L156) are implemented, both primary and secondary caches are waited upon, so I chose to go that route and also wait for the Habitat cache to be synced.