### PR TITLE
Start multiple workers

### DIFF
--- a/cmd/habitat-operator/main.go
+++ b/cmd/habitat-operator/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 
 	"github.com/go-kit/kit/log"
@@ -105,7 +106,7 @@ func run() int {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	go hc.Run(ctx)
+	go hc.Run(runtime.NumCPU(), ctx)
 
 	term := make(chan os.Signal)
 	// Relay these signals to the `term` channel.

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -110,7 +110,7 @@ func New(config Config, logger log.Logger) (*HabitatController, error) {
 }
 
 // Run starts a Habitat resource controller.
-func (hc *HabitatController) Run(ctx context.Context) error {
+func (hc *HabitatController) Run(workers int, ctx context.Context) error {
 	// Make sure the work queue is shutdown which will trigger workers to end.
 	defer hc.queue.ShutDown()
 
@@ -131,9 +131,12 @@ func (hc *HabitatController) Run(ctx context.Context) error {
 	}
 	level.Debug(hc.logger).Log("msg", "Caches synced")
 
-	// Start the synchronous queue consumer. If the worker exits because of a
+	// Start the synchronous queue consumers. If a worker exits because of a
 	// failed job, it will be restarted after a delay of 1 second.
-	go wait.Until(hc.worker, time.Second, ctx.Done())
+	for i := 0; i < workers; i++ {
+		level.Debug(hc.logger).Log("msg", "Starting worker", "id", i)
+		go wait.Until(hc.worker, time.Second, ctx.Done())
+	}
 
 	// This channel is closed when the context is canceled or times out.
 	<-ctx.Done()

--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
 	appsv1beta1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
@@ -130,8 +131,9 @@ func (hc *HabitatController) Run(ctx context.Context) error {
 	}
 	level.Debug(hc.logger).Log("msg", "Caches synced")
 
-	// Start the synchronous queue consumer.
-	go hc.worker()
+	// Start the synchronous queue consumer. If the worker exits because of a
+	// failed job, it will be restarted after a delay of 1 second.
+	go wait.Until(hc.worker, time.Second, ctx.Done())
 
 	// This channel is closed when the context is canceled or times out.
 	<-ctx.Done()


### PR DESCRIPTION
With this PR, we start `runtime.NumCPU()` workers instead of just one. As mentioned in the commit, we might want to, in the future, make this value configurable.

Closes #67.