### PR TITLE
Change log level about IP removal to debug

### DIFF
--- a/pkg/habitat/controller/controller.go
+++ b/pkg/habitat/controller/controller.go
@@ -480,7 +480,7 @@ func (hc *HabitatController) handleConfigMap(h *crv1.Habitat) error {
 				return err
 			}
 
-			level.Info(hc.logger).Log("msg", "removed peer IP from ConfigMap", "name", newCM.Name)
+			level.Debug(hc.logger).Log("msg", "removed peer IP from ConfigMap", "name", newCM.Name)
 
 			return nil
 		}


### PR DESCRIPTION
The "removed peer IP from ConfigMap" msg was not useful in log level
info. Let me know what you think? I found it non informative and a bit spammy.