### PR TITLE
Increase indentation in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## [v0.2.0](https://github.com/kinvolk/habitat-operator/tree/v0.2.0) (2017-20-11)
 [Full changelog](https://github.com/kinvolk/habitat-operator/compare/v0.1.0...v0.2.0)
 
-## Features & Enhancements
+### Features & Enhancements
 
 - React to all events involved with a Habitat object for faster and more consistent reconciliation with the desired state. [#113](https://github.com/kinvolk/habitat-operator/pull/113)
 - Update Deployment when Habitat object is updated [#124](https://github.com/kinvolk/habitat-operator/pull/124)
 
-## Bug fixes
+### Bug fixes
 
 - Fix Habitat removal [#125](https://github.com/kinvolk/habitat-operator/pull/125)
 


### PR DESCRIPTION
Features and bugfixes should be deeper in the hierarchy than the version they belong to.