### PR TITLE
Switch to little-endian dates in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Habitat operator CHANGELOG
 
-## [v0.2.0](https://github.com/kinvolk/habitat-operator/tree/v0.2.0) (2017-20-11)
+## [v0.2.0](https://github.com/kinvolk/habitat-operator/tree/v0.2.0) (20-11-2017)
 [Full changelog](https://github.com/kinvolk/habitat-operator/compare/v0.1.0...v0.2.0)
 
 ### Features & Enhancements


### PR DESCRIPTION
Little endian dates are [much more common][0] across the globe, whereas
big-endian ones are almost only used in the USA.

[0]: https://en.wikipedia.org/wiki/Date_format_by_country

Signed-off-by: Lorenzo Manacorda <lorenzo@kinvolk.io>