### PR TITLE
Avoid installing dependencies when building image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 
 linux:
 	# Compile statically linked binary for linux.
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build --ldflags="-s" -o habitat-operator github.com/kinvolk/habitat-operator/cmd/habitat-operator
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s" -o habitat-operator github.com/kinvolk/habitat-operator/cmd/habitat-operator
 
 image: linux
 	docker build -t "$(IMAGE):$(TAG)" .

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 
 linux:
 	# Compile statically linked binary for linux.
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -i --ldflags="-s" -o habitat-operator github.com/kinvolk/habitat-operator/cmd/habitat-operator
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build --ldflags="-s" -o habitat-operator github.com/kinvolk/habitat-operator/cmd/habitat-operator
 
 image: linux
 	docker build -t "$(IMAGE):$(TAG)" .


### PR DESCRIPTION
When building an image, we want to avoid the side effect of installing binaries.

Moreover, the `-i` flag required `sudo` on my machine (not sure if it's a general problem though).