### PR TITLE
Switch to e2e testing against RBAC enabled cluster and refactor tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ git:
 
 before_script:
 # Download kubectl, which is a requirement for using minikube.
-- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 # Download minikube.
 - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-- sudo minikube start --vm-driver=none --kubernetes-version=v1.7.0
+- sudo minikube start --vm-driver=none --kubernetes-version=v1.8.0 --extra-config=apiserver.Authorization.Mode=RBAC
 # Fix the kubectl context, as it's often stale.
 - minikube update-context
 # Wait for Kubernetes to be up and ready.

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ e2e:
 
 clean-test:
 	kubectl delete namespace testing
+	kubectl delete clusterrolebinding habitat-operator
+	kubectl delete clusterrole habitat-operator
 
 update-version:
 	find examples -name "*.yml" -type f -exec sed -i.bak "s/habitat-operator:.*/habitat-operator:v$$(cat VERSION)/g" '{}' \;

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -17,7 +17,6 @@
 package framework
 
 import (
-	habv1 "github.com/kinvolk/habitat-operator/pkg/apis/habitat/v1"
 	habclient "github.com/kinvolk/habitat-operator/pkg/client"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -101,8 +100,7 @@ func (f *Framework) setupOperator() error {
 		return err
 	}
 
-	// Wait until the operator is ready.
-	f.WaitForResources(name, 1)
+	f.WaitForResources("name", d.ObjectMeta.Name, 1)
 
 	return nil
 }

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -25,37 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// NewStandaloneHabitat returns a new Standalone Habitat.
-func NewStandaloneHabitat(habitatName, group, image string) *habv1.Habitat {
-	return &habv1.Habitat{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: habitatName,
-		},
-		Spec: habv1.HabitatSpec{
-			Image: image,
-			Count: 1,
-			Service: habv1.Service{
-				Group:    group,
-				Topology: habv1.TopologyStandalone,
-			},
-		},
-	}
-}
-
-// AddConfigToHabitat adds a ConfigSecretName field to the Habitat.
-func AddConfigToHabitat(habitat *habv1.Habitat) {
-	habitat.Spec.Service.ConfigSecretName = habitat.ObjectMeta.Name
-}
-
-// AddBindToHabitat appends bind fields to the Habitat.
-func AddBindToHabitat(habitat *habv1.Habitat, bindName, bindService string) {
-	habitat.Spec.Service.Bind = append(habitat.Spec.Service.Bind, habv1.Bind{
-		Name:    bindName,
-		Service: bindService,
-		Group:   habitat.Spec.Service.Group,
-	})
-}
-
 // CreateHabitat creates a Habitat.
 func (f *Framework) CreateHabitat(habitat *habv1.Habitat) error {
 	return f.Client.Post().

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -69,14 +69,14 @@ func (f *Framework) CreateHabitat(habitat *habv1.Habitat) error {
 // WaitForResources waits until numPods are in the "Running" state.
 // We wait for pods, because those take the longest to create.
 // Waiting for anything else would be already testing.
-func (f *Framework) WaitForResources(habitatName string, numPods int) error {
+func (f *Framework) WaitForResources(labelName, habitatName string, numPods int) error {
 	return wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
 		fs := fields.SelectorFromSet(fields.Set{
 			"status.phase": "Running",
 		})
 
 		ls := labels.SelectorFromSet(labels.Set{
-			habv1.HabitatNameLabel: habitatName,
+			labelName: habitatName,
 		})
 
 		pods, err := f.KubeClient.CoreV1().Pods(TestNs).List(metav1.ListOptions{FieldSelector: fs.String(), LabelSelector: ls.String()})

--- a/test/e2e/resources/bind-config/habitat-go.yml
+++ b/test/e2e/resources/bind-config/habitat-go.yml
@@ -1,0 +1,13 @@
+apiVersion: habitat.sh/v1
+kind: Habitat
+metadata:
+  name: go
+spec:
+  image: kinvolk/bindgo-hab
+  count: 1
+  service:
+    topology: standalone
+    bind:
+      - name: db
+        service: postgresql
+        group: default

--- a/test/e2e/resources/bind-config/habitat-postgresql.yml
+++ b/test/e2e/resources/bind-config/habitat-postgresql.yml
@@ -1,0 +1,13 @@
+apiVersion: habitat.sh/v1
+kind: Habitat 
+metadata:
+  # Name must match the Habitat service name.
+  name: postgresql
+spec:
+  image: kinvolk/postgresql-hab
+  count: 1
+  service:
+    # Name of the secret.
+    # This is mounted inside of the pod as a user.toml file.
+    configSecretName: user-toml-secret
+    topology: standalone

--- a/test/e2e/resources/bind-config/secret.yml
+++ b/test/e2e/resources/bind-config/secret.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: user-toml-secret
+type: Opaque
+data:
+  # Each item needs to be encoded in base64, as Kubernetes expects that encoding.
+  # Plain text content of the secret: "port = 4444"
+  # This overrides the port set in the postgresql Habitat service.
+  user.toml: cG9ydCA9IDQ0NDQ=

--- a/test/e2e/resources/bind-config/service.yml
+++ b/test/e2e/resources/bind-config/service.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: go-service
+spec:
+  selector:
+    habitat-name: go
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: 30001
+    port: 5555
+    protocol: TCP

--- a/test/e2e/resources/operator/cluster-role-binding.yml
+++ b/test/e2e/resources/operator/cluster-role-binding.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: habitat-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: habitat-operator
+subjects:
+- kind: ServiceAccount
+  name: habitat-operator
+  namespace: testing

--- a/test/e2e/resources/operator/cluster-role.yml
+++ b/test/e2e/resources/operator/cluster-role.yml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: habitat-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups:
+  - habitat.sh
+  resources:
+  - habitats
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["get"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list"]

--- a/test/e2e/resources/operator/habitat.yml
+++ b/test/e2e/resources/operator/habitat.yml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: habitat-operator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: habitat-operator
+    spec:
+      containers:
+      - name: habitat-operator
+        image: kinvolk/habitat-operator:v0.3.0
+      serviceAccountName: habitat-operator

--- a/test/e2e/resources/operator/rbac.yml
+++ b/test/e2e/resources/operator/rbac.yml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: habitat-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups:
+  - habitat.sh
+  resources:
+  - habitats
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["get"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list"]

--- a/test/e2e/resources/operator/service-account.yml
+++ b/test/e2e/resources/operator/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: habitat-operator

--- a/test/e2e/resources/standalone/habitat.yml
+++ b/test/e2e/resources/standalone/habitat.yml
@@ -1,0 +1,12 @@
+apiVersion: habitat.sh/v1
+kind: Habitat
+metadata:
+  name: example-standalone-habitat
+spec:
+  # the core/nginx habitat service packaged as a Docker image
+  image: kinvolk/nginx-hab
+  count: 1
+  service:
+    topology: standalone
+    # if not present, defaults to "default"
+    group: foobar


### PR DESCRIPTION
This PR introduces testing against a RBAC enabled cluster. I also introduce taking the manifest files from the examples rather then creating the resources through the API in code. See issue https://github.com/kinvolk/habitat-operator/issues/108 for more information.

Also bumped the version of cluster to 1.8.0.

Closes https://github.com/kinvolk/habitat-operator/issues/108 and https://github.com/kinvolk/habitat-operator/issues/105 and https://github.com/kinvolk/habitat-operator/issues/148.

This improved the e2e tests from aprox. 257.289s seconds down to 121.449 seconds. 🎉 