### PR TITLE
Use cache for ConfigMaps

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -172,11 +172,11 @@ func (hc *HabitatController) cacheHabitats() {
 }
 
 func (hc *HabitatController) cacheDeployments() {
-	source := cache.NewListWatchFromClient(
+	source := newListWatchFromClientWithLabels(
 		hc.config.KubernetesClientset.AppsV1beta1().RESTClient(),
 		"deployments",
 		apiv1.NamespaceAll,
-		fields.Everything())
+		labelListOptions())
 
 	hc.deployInformer = cache.NewSharedIndexInformer(
 		source,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -218,18 +218,11 @@ func (hc *HabitatController) cacheConfigMaps() {
 }
 
 func (hc *HabitatController) watchPods(ctx context.Context) {
-	ls := labels.SelectorFromSet(labels.Set(map[string]string{
-		habv1beta1.HabitatLabel: "true",
-	}))
-
-	options := metav1.ListOptions{
-		LabelSelector: ls.String(),
-	}
 	source := newListWatchFromClientWithLabels(
 		hc.config.KubernetesClientset.CoreV1().RESTClient(),
 		"pods",
 		apiv1.NamespaceAll,
-		options)
+		labelListOptions())
 
 	c := cache.NewSharedIndexInformer(
 		source,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -866,10 +866,6 @@ func (hc *HabitatController) conform(key string) error {
 		} else {
 			return err
 		}
-		_, err = hc.config.KubernetesClientset.AppsV1beta1().Deployments(h.Namespace).Get(deployment.Name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
 
 		level.Debug(hc.logger).Log("msg", "deployment already existed", "name", deployment.Name)
 	} else {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -285,15 +285,13 @@ func (hc *HabitatController) handleDeployAdd(obj interface{}) {
 		return
 	}
 
-	if isHabitatObject(&d.ObjectMeta) {
-		h, err := hc.getHabitatFromLabeledResource(d)
-		if err != nil {
-			level.Error(hc.logger).Log("msg", "Could not find Habitat for Deployment", "name", d.Name)
-			return
-		}
-
-		hc.enqueue(h)
+	h, err := hc.getHabitatFromLabeledResource(d)
+	if err != nil {
+		level.Error(hc.logger).Log("msg", "Could not find Habitat for Deployment", "name", d.Name)
+		return
 	}
+
+	hc.enqueue(h)
 }
 
 func (hc *HabitatController) handleDeployUpdate(oldObj, newObj interface{}) {
@@ -303,15 +301,13 @@ func (hc *HabitatController) handleDeployUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	if isHabitatObject(&d.ObjectMeta) {
-		h, err := hc.getHabitatFromLabeledResource(d)
-		if err != nil {
-			level.Error(hc.logger).Log("msg", "Could not find Habitat for Deployment", "name", d.Name)
-			return
-		}
-
-		hc.enqueue(h)
+	h, err := hc.getHabitatFromLabeledResource(d)
+	if err != nil {
+		level.Error(hc.logger).Log("msg", "Could not find Habitat for Deployment", "name", d.Name)
+		return
 	}
+
+	hc.enqueue(h)
 }
 
 func (hc *HabitatController) handleDeployDelete(obj interface{}) {
@@ -321,16 +317,14 @@ func (hc *HabitatController) handleDeployDelete(obj interface{}) {
 		return
 	}
 
-	if isHabitatObject(&d.ObjectMeta) {
-		h, err := hc.getHabitatFromLabeledResource(d)
-		if err != nil {
-			// Could not find Habitat, it must have already been removed.
-			level.Debug(hc.logger).Log("msg", "Could not find Habitat for Deployment", "name", d.Name)
-			return
-		}
-
-		hc.enqueue(h)
+	h, err := hc.getHabitatFromLabeledResource(d)
+	if err != nil {
+		// Could not find Habitat, it must have already been removed.
+		level.Debug(hc.logger).Log("msg", "Could not find Habitat for Deployment", "name", d.Name)
+		return
 	}
+
+	hc.enqueue(h)
 }
 
 func (hc *HabitatController) enqueueCM(obj interface{}) {
@@ -340,18 +334,16 @@ func (hc *HabitatController) enqueueCM(obj interface{}) {
 		return
 	}
 
-	if isHabitatObject(&cm.ObjectMeta) {
-		cache.ListAll(hc.habInformer.GetStore(), labels.Everything(), func(obj interface{}) {
-			h, ok := obj.(*habv1beta1.Habitat)
-			if !ok {
-				level.Error(hc.logger).Log("msg", "Failed to type assert Habitat", "obj", obj)
-				return
-			}
-			if h.Namespace == cm.GetNamespace() {
-				hc.enqueue(h)
-			}
-		})
-	}
+	cache.ListAll(hc.habInformer.GetStore(), labels.Everything(), func(obj interface{}) {
+		h, ok := obj.(*habv1beta1.Habitat)
+		if !ok {
+			level.Error(hc.logger).Log("msg", "Failed to type assert Habitat", "obj", obj)
+			return
+		}
+		if h.Namespace == cm.GetNamespace() {
+			hc.enqueue(h)
+		}
+	})
 }
 
 func (hc *HabitatController) handleCMAdd(obj interface{}) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -473,7 +473,7 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 
 	if len(runningPods) == 0 {
 		// No running Pods, create an empty ConfigMap.
-		newCM := newConfigMap("")
+		newCM := newConfigMap("", h)
 
 		cm, err := hc.config.KubernetesClientset.CoreV1().ConfigMaps(h.Namespace).Create(newCM)
 		if err != nil {
@@ -506,7 +506,7 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 	// There are running Pods, add the IP of one of them to the ConfigMap.
 	leaderIP := runningPods[0].Status.PodIP
 
-	newCM := newConfigMap(leaderIP)
+	newCM := newConfigMap(leaderIP, h)
 
 	cm, err := hc.config.KubernetesClientset.CoreV1().ConfigMaps(h.Namespace).Create(newCM)
 	if err != nil {
@@ -918,10 +918,11 @@ func habitatKeyFromLabeledResource(r metav1.Object) (string, error) {
 	return key, nil
 }
 
-func newConfigMap(ip string) *apiv1.ConfigMap {
+func newConfigMap(ip string, h *habv1beta1.Habitat) *apiv1.ConfigMap {
 	return &apiv1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: configMapName,
+			Name:      configMapName,
+			Namespace: h.Namespace,
 			Labels: map[string]string{
 				habv1beta1.HabitatLabel: "true",
 			},

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -416,7 +416,7 @@ func (hc *HabitatController) handlePodUpdate(oldObj, newObj interface{}) {
 
 	h, err := hc.getHabitatFromLabeledResource(newPod)
 	if err != nil {
-		if hErr, ok := err.(habitatNotFoundError); !ok {
+		if hErr, ok := err.(keyNotFoundError); !ok {
 			level.Error(hc.logger).Log("msg", hErr)
 			return
 		}
@@ -443,7 +443,7 @@ func (hc *HabitatController) handlePodDelete(obj interface{}) {
 
 	h, err := hc.getHabitatFromLabeledResource(pod)
 	if err != nil {
-		if hErr, ok := err.(habitatNotFoundError); !ok {
+		if hErr, ok := err.(keyNotFoundError); !ok {
 			level.Error(hc.logger).Log("msg", hErr)
 			return
 		}
@@ -921,7 +921,7 @@ func (hc *HabitatController) getHabitatFromLabeledResource(r metav1.Object) (*ha
 		return nil, err
 	}
 	if !exists {
-		return nil, habitatNotFoundError{key: key}
+		return nil, keyNotFoundError{key: key}
 	}
 
 	h, ok := obj.(*habv1beta1.Habitat)
@@ -975,7 +975,7 @@ func (hc *HabitatController) findConfigMapInCache(cm *apiv1.ConfigMap) (*apiv1.C
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("Could not find ConfigMap with key %s", k)
+		return nil, keyNotFoundError{key: k}
 	}
 
 	return obj.(*apiv1.ConfigMap), nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -195,19 +195,11 @@ func (hc *HabitatController) cacheDeployments() {
 }
 
 func (hc *HabitatController) cacheConfigMaps() {
-	ls := labels.SelectorFromSet(labels.Set(map[string]string{
-		habv1beta1.HabitatLabel: "true",
-	}))
-
-	options := metav1.ListOptions{
-		LabelSelector: ls.String(),
-	}
-
 	source := newListWatchFromClientWithLabels(
 		hc.config.KubernetesClientset.CoreV1().RESTClient(),
 		"configmaps",
 		apiv1.NamespaceAll,
-		options)
+		labelListOptions())
 
 	hc.cmInformer = cache.NewSharedIndexInformer(
 		source,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -417,7 +417,7 @@ func (hc *HabitatController) handlePodUpdate(oldObj, newObj interface{}) {
 	h, err := hc.getHabitatFromLabeledResource(newPod)
 	if err != nil {
 		if hErr, ok := err.(keyNotFoundError); !ok {
-			level.Error(hc.logger).Log("msg", hErr)
+			level.Error(hc.logger).Log("msg", hErr, "key", hErr.key)
 			return
 		}
 
@@ -444,7 +444,7 @@ func (hc *HabitatController) handlePodDelete(obj interface{}) {
 	h, err := hc.getHabitatFromLabeledResource(pod)
 	if err != nil {
 		if hErr, ok := err.(keyNotFoundError); !ok {
-			level.Error(hc.logger).Log("msg", hErr)
+			level.Error(hc.logger).Log("msg", hErr, "key", hErr.key)
 			return
 		}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -117,9 +117,9 @@ func (hc *HabitatController) Run(workers int, ctx context.Context) error {
 
 	level.Info(hc.logger).Log("msg", "Watching Habitat objects")
 
-	hc.cacheHab()
-	hc.cacheDeployment()
-	hc.cacheConfigMap()
+	hc.cacheHabitats()
+	hc.cacheDeployments()
+	hc.cacheConfigMaps()
 	hc.watchPods(ctx)
 
 	go hc.habInformer.Run(ctx.Done())
@@ -146,7 +146,7 @@ func (hc *HabitatController) Run(workers int, ctx context.Context) error {
 	return ctx.Err()
 }
 
-func (hc *HabitatController) cacheHab() {
+func (hc *HabitatController) cacheHabitats() {
 	source := cache.NewListWatchFromClient(
 		hc.config.HabitatClient,
 		habv1beta1.HabitatResourcePlural,
@@ -171,7 +171,7 @@ func (hc *HabitatController) cacheHab() {
 	hc.habInformerSynced = hc.habInformer.HasSynced
 }
 
-func (hc *HabitatController) cacheDeployment() {
+func (hc *HabitatController) cacheDeployments() {
 	source := cache.NewListWatchFromClient(
 		hc.config.KubernetesClientset.AppsV1beta1().RESTClient(),
 		"deployments",
@@ -194,7 +194,7 @@ func (hc *HabitatController) cacheDeployment() {
 	hc.deployInformerSynced = hc.deployInformer.HasSynced
 }
 
-func (hc *HabitatController) cacheConfigMap() {
+func (hc *HabitatController) cacheConfigMaps() {
 	ls := labels.SelectorFromSet(labels.Set(map[string]string{
 		habv1beta1.HabitatLabel: "true",
 	}))

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -27,12 +27,12 @@ import (
 
 const leaderFollowerTopologyMinCount = 3
 
-type habitatNotFoundError struct {
+type keyNotFoundError struct {
 	key string
 }
 
-func (err habitatNotFoundError) Error() string {
-	return fmt.Sprintf("could not find Habitat with key %s", err.key)
+func (err keyNotFoundError) Error() string {
+	return fmt.Sprintf("could not find Object with key %s in the cache", err.key)
 }
 
 func validateCustomObject(h habv1beta1.Habitat) error {

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -20,6 +20,7 @@ import (
 	habv1beta1 "github.com/kinvolk/habitat-operator/pkg/apis/habitat/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
@@ -81,4 +82,14 @@ func newListWatchFromClientWithLabels(c cache.Getter, resource string, namespace
 			Watch()
 	}
 	return &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
+}
+
+func labelListOptions() metav1.ListOptions {
+	ls := labels.SelectorFromSet(labels.Set(map[string]string{
+		habv1beta1.HabitatLabel: "true",
+	}))
+
+	return metav1.ListOptions{
+		LabelSelector: ls.String(),
+	}
 }


### PR DESCRIPTION
This PR adds a cache for ConfigMaps, and uses that - instead of calling the API directly - whenever we want to perform a `GET`. Writes and updates obviously still go to the API.

It also does a couple other things:

* Sets up all watchers to only returned labelled objects
* Removes manual checks for the label in the handlers, because see above

I decided not to implement a cache for the secrets because I'm not convinced it makes sense in this case: in the other situations, we check the cache only when creating an object fails. By that time, we have created an object, so we have the necessary `struct`.

In the case of Secrets, we assume they have been created by the user beforehand, so we shouldn't have to create one just so that we have something to pass to `MetaNamespaceKeyFunc`.

Closes #156.