### PR TITLE
Add helm chart for the operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,13 @@ clean-test:
 	kubectl delete clusterrole habitat-operator
 
 update-version:
-	find examples -name "*.yml" -type f -exec sed -i.bak "s/habitat-operator:.*/habitat-operator:v$$(cat VERSION)/g" '{}' \;
-	find examples -name "*.yml.bak" -type f -exec rm '{}' \;
+	find examples helm -name "*.yml" -o -name "*.yaml" -type f \
+		-exec sed -i.bak \
+		-e "s/habitat-operator:.*/habitat-operator:v$$(cat VERSION)/g" \
+		-e "s/tag:.*/tag: v$$(cat VERSION)/g" \
+		-e "s/version:.*/version: $$(cat VERSION)/g" \
+		'{}' \;
+	find examples helm -name "*.yml.bak" -o -name "*.yaml.bak" -type f \
+		-exec rm '{}' \;
 
 .PHONY: build test linux image e2e clean-test update-version

--- a/helm/habitat-operator/.helmignore
+++ b/helm/habitat-operator/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/habitat-operator/Chart.yaml
+++ b/helm/habitat-operator/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+description: A Kubernetes controller that manages Habitat services in a Kubernetes cluster.
+engine: gotpl
+maintainers:
+  - name: Zeeshan Ali
+    email: zeeshan@kinvolk.io
+name: habitat-operator
+sources:
+  - https://github.com/kinvolk/habitat-operator
+version: 0.4.0

--- a/helm/habitat-operator/README.md
+++ b/helm/habitat-operator/README.md
@@ -1,0 +1,109 @@
+# habitat-operator
+
+Installs [habitat-operator](https://github.com/kinvolk/habitat-operator) to manage Habitat services in a Kubernetes cluster.
+
+## TL;DR;
+
+```console
+$ helm repo add habitat https://kinvolk.github.io/habitat-operator/helm/charts/stable/
+$ helm install habitat/habitat-operator
+```
+
+## Introduction
+
+This chart bootstraps a [habitat-operator](https://github.com/kinvolk/habitat-operator) deployment in a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+See [Habitat Operator's README](https://github.com/kinvolk/habitat-operator/blob/master/README.md).
+
+### RBAC
+If role-based access control (RBAC) is enabled in your cluster, you may need to give Tiller (the server-side component of Helm) additional permissions. **If RBAC is not enabled, be sure to set `rbacEnable` to `false` when installing the chart.**
+
+1. Create a ServiceAccount for Tiller in the `kube-system` namespace
+```console
+$ kubectl -n kube-system create sa tiller
+```
+
+2. Create a ClusterRoleBinding for Tiller
+
+#### kubectl v1.5.x
+
+```console
+$ cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system
+EOF
+```
+
+#### kubectl >= v1.6.x
+
+```console
+$ kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+```
+
+3. Install Tiller, specifying the new ServiceAccount
+```console
+$ helm init --service-account tiller
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release habitat/habitat-operator
+```
+
+The command deploys habitat-operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the habitat-operator chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`image.repository` | Image | `docker.io/kinvolk/habitat-operator`
+`image.tag` | Image tag | The latest release tag (e.g `v0.4.0`)
+`image.pullPolicy` | Image pull policy | `IfNotPresent`
+`nodeSelector` | Node labels for pod assignment | `{}`
+`rbacEnable` | If true, create & use RBAC resources | `true`
+`resources` | Pod resource requests & limits | `{}`
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release habitat/habitat-operator --set sendAnalytics=true
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release habitat/habitat-operator -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Hosting
+
+The Helm chart repository is managed on the [`gh-pages` branch](https://github.com/kinvolk/habitat-operator/tree/gh-pages) and instructions for repository management can be found [here](https://github.com/kinvolk/habitat-operator/tree/gh-pages/helm/charts).

--- a/helm/habitat-operator/templates/NOTES.txt
+++ b/helm/habitat-operator/templates/NOTES.txt
@@ -1,0 +1,4 @@
+The Habitat Operator has been installed. Check its status by running:
+  kubectl --namespace {{ .Release.Namespace }} get pods -l "app={{ template "habitat-operator.name" . }},release={{ .Release.Name }}"
+
+You can now deploy Habitat services in the cluster.

--- a/helm/habitat-operator/templates/_helpers.tpl
+++ b/helm/habitat-operator/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "habitat-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "habitat-operator.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/helm/habitat-operator/templates/clusterrole.yaml
+++ b/helm/habitat-operator/templates/clusterrole.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.rbacEnable }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- end }}
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "habitat-operator.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "habitat-operator.fullname" . }}
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups:
+  - habitat.sh
+  resources:
+  - habitats
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["get"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list"]
+{{- end }}

--- a/helm/habitat-operator/templates/clusterrolebinding.yaml
+++ b/helm/habitat-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rbacEnable }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "habitat-operator.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "habitat-operator.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "habitat-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "habitat-operator.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/habitat-operator/templates/deployment.yaml
+++ b/helm/habitat-operator/templates/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "habitat-operator.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    operator: habitat
+    release: {{ .Release.Name }}
+  name: {{ template "habitat-operator.fullname" . }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "habitat-operator.name" . }}
+        operator: habitat
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "habitat-operator.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.rbacEnable }}
+      serviceAccountName: {{ template "habitat-operator.fullname" . }}
+    {{- end }}

--- a/helm/habitat-operator/templates/serviceaccount.yaml
+++ b/helm/habitat-operator/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbacEnable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "habitat-operator.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "habitat-operator.fullname" . }}
+{{- end }}

--- a/helm/habitat-operator/values.yaml
+++ b/helm/habitat-operator/values.yaml
@@ -1,0 +1,25 @@
+## Habitat-operator image
+##
+image:
+  repository: docker.io/kinvolk/habitat-operator
+  tag: v0.4.0
+  pullPolicy: IfNotPresent
+
+## Node labels for habitat-operator pod assignment
+##
+nodeSelector: {}
+
+## If true, create & use RBAC resources
+##
+rbacEnable: true
+
+## Habitat-operator resource limits & requests
+## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+  # limits:
+  #   cpu: 200m
+  #   memory: 100Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 50Mi

--- a/release.md
+++ b/release.md
@@ -27,6 +27,10 @@ In the root directory of the repository generate the Docker image and push it to
     docker tag kinvolk/habitat-operator:vx.y.z kinvolk/habitat-operator:latest
     docker push kinvolk/habitat-operator:latest
 
+## Generate the Helm chart
+
+Switch to `gh-pages` branch and follow the steps in the `helm/charts/README.md` file.
+
 ## Do the release
 
-Head over to GitHub and edit the release notes with the notes that were included in the `CHANGELOG.md` file. Also include the generated Docker image in the release notes.
+Head over to GitHub and edit the release notes with the notes that were included in the `CHANGELOG.md` file. Also include the generated Docker image and Helm chart in the release notes.


### PR DESCRIPTION
This is the source for the Helm chart. You can use:

helm package helm/habitat-operator

command to create a chart package for the operator for distribution.

This chart uses the docker image of the latest release: 0.4.0.