### PR TITLE
Use service name when forming path for user.toml

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -715,7 +715,7 @@ func (hc *HabitatController) newDeployment(h *habv1.Habitat) (*appsv1beta1.Deplo
 			Name: initialConfigFilename,
 			// The Habitat supervisor creates a directory for each service under /hab/svc/<servicename>.
 			// We need to place the user.toml file in there in order for it to be detected.
-			MountPath: fmt.Sprintf("/hab/svc/%s/%s", h.Name, userTOMLFile),
+			MountPath: fmt.Sprintf("/hab/svc/%s/%s", h.Spec.Service.Name, userTOMLFile),
 			SubPath:   userTOMLFile,
 			ReadOnly:  false,
 		}

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -75,7 +75,11 @@ func (f *Framework) WaitForEndpoints(habitatName string) error {
 			return false, err
 		}
 
-		if len(ep.Subsets) == 0 && len(ep.Subsets[0].Addresses) == 0 {
+		if len(ep.Subsets) == 0 {
+			return false, nil
+		}
+
+		if len(ep.Subsets[0].Addresses) == 0 {
 			return false, nil
 		}
 

--- a/test/e2e/resources/bind-config/habitat-go.yml
+++ b/test/e2e/resources/bind-config/habitat-go.yml
@@ -1,7 +1,7 @@
 apiVersion: habitat.sh/v1
 kind: Habitat
 metadata:
-  name: go
+  name: go-test-123
 spec:
   image: kinvolk/bindgo-hab
   count: 1

--- a/test/e2e/resources/bind-config/habitat-postgresql.yml
+++ b/test/e2e/resources/bind-config/habitat-postgresql.yml
@@ -1,14 +1,11 @@
 apiVersion: habitat.sh/v1
 kind: Habitat 
 metadata:
-  # Name must match the Habitat service name.
-  name: postgresql
+  name: postgresql-test-123
 spec:
   image: kinvolk/postgresql-hab
   count: 1
   service:
     name: postgresql
-    # Name of the secret.
-    # This is mounted inside of the pod as a user.toml file.
     configSecretName: user-toml-secret
     topology: standalone

--- a/test/e2e/resources/bind-config/service.yml
+++ b/test/e2e/resources/bind-config/service.yml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: go-service
+  name: go-test-123
 spec:
   selector:
-    habitat-name: go
+    habitat-name: go-test-123
   type: NodePort
   ports:
   - name: web

--- a/test/e2e/resources/standalone/habitat.yml
+++ b/test/e2e/resources/standalone/habitat.yml
@@ -1,13 +1,11 @@
 apiVersion: habitat.sh/v1
 kind: Habitat
 metadata:
-  name: example-standalone-habitat
+  name: standalone-test-123
 spec:
-  # the core/nginx habitat service packaged as a Docker image
   image: kinvolk/nginx-hab
   count: 1
   service:
     name: nginx
     topology: standalone
-    # if not present, defaults to "default"
     group: foobar


### PR DESCRIPTION
Due to recent changes, user now specifies in the `Service.Name` field the name of the service, and we do not take it from the habitat Name anymore. This should fix the issue we are seeing.

I am a bit confused why the tests passed, but it could also be why they were failing so often? 