### PR TITLE
Use numeric dependency versions for clarity

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -298,6 +298,7 @@
     "storage/v1beta1"
   ]
   revision = "af4bc157c3a209798fc897f6d4aaaaeb6c2e0d6a"
+  version = "kubernetes-1.9.0"
 
 [[projects]]
   name = "k8s.io/apiextensions-apiserver"
@@ -309,6 +310,7 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
   ]
   revision = "98ecf7bbd60f9f11a72000e4f05203f542136219"
+  version = "kubernetes-1.9.0"
 
 [[projects]]
   name = "k8s.io/apimachinery"
@@ -361,6 +363,7 @@
     "third_party/forked/golang/reflect"
   ]
   revision = "180eddb345a5be3a157cea1c624700ad5bd27b8f"
+  version = "kubernetes-1.9.0"
 
 [[projects]]
   name = "k8s.io/client-go"
@@ -417,6 +420,7 @@
     "util/workqueue"
   ]
   revision = "78700dec6369ba22221b72770783300f143df150"
+  version = "v6.0.0"
 
 [[projects]]
   branch = "master"
@@ -427,6 +431,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "21f5a072550de50f7878d494fadb160a999655ada2250d555d66124c199ea228"
+  inputs-digest = "9eff3067e72a59d72a7e47ff2e045d75e6c04dea4e7601941bf8a3f4b6f2ad4e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,8 +26,8 @@
   unused-packages = true
 
 [[constraint]]
-name = "k8s.io/client-go"
-version = "v6.0.0"
+  name = "k8s.io/client-go"
+  version = "v6.0.0"
 
 [[constraint]]
   name = "k8s.io/api"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,16 +27,16 @@
 
 [[constraint]]
 name = "k8s.io/client-go"
-revision = "78700dec6369ba22221b72770783300f143df150"
+version = "v6.0.0"
 
 [[constraint]]
   name = "k8s.io/api"
-  revision = "af4bc157c3a209798fc897f6d4aaaaeb6c2e0d6a"
+  version = "kubernetes-1.9.0"
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  revision = "98ecf7bbd60f9f11a72000e4f05203f542136219"
+  version = "kubernetes-1.9.0"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  revision = "180eddb345a5be3a157cea1c624700ad5bd27b8f"
+  version = "kubernetes-1.9.0"


### PR DESCRIPTION
Revisions are opaque, versions make it clear which version we're
running.

Signed-off-by: Lorenzo Manacorda <lorenzo@kinvolk.io>