### PR TITLE
Fix incomplete API downgrade

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
-# API
+# API v1beta1
 
 The following is a description of the Habitat operator API. To see manifest example files, have a look at the [examples directory](https://github.com/kinvolk/habitat-operator/tree/master/examples).
 

--- a/pkg/apis/habitat/v1beta1/register.go
+++ b/pkg/apis/habitat/v1beta1/register.go
@@ -26,10 +26,13 @@ var (
 )
 
 // GroupName is the group name used in this package.
-const GroupName = "habitat.sh"
+const (
+	GroupName = "habitat.sh"
+	Version   = "v1beta1"
+)
 
 // SchemeGroupVersion is the group version used to register these objects.
-var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1beta1"}
+var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: Version}
 
 // Resource takes an unqualified resource and returns a Group-qualified GroupResource.
 func Resource(resource string) schema.GroupResource {

--- a/pkg/apis/habitat/v1beta1/register.go
+++ b/pkg/apis/habitat/v1beta1/register.go
@@ -29,7 +29,7 @@ var (
 const GroupName = "habitat.sh"
 
 // SchemeGroupVersion is the group version used to register these objects.
-var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}
+var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1beta1"}
 
 // Resource takes an unqualified resource and returns a Group-qualified GroupResource.
 func Resource(resource string) schema.GroupResource {


### PR DESCRIPTION
This should have been done in #167. I don't understand how this was not by our tests, since without this, Habitat objects cannot be created, since they reference `v1beta1`, while the CRD only exists under `v1`.