### PR TITLE
Add Env key

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,7 @@ The following is a description of the Habitat operator API. To see manifest exam
 | configSecretName | configSecretName is the name of the Kubernetes Secret containing the config file - user.toml - that the user has previously created. Habitat will use it for initial configuration of the service. | string | false |
 | ringSecretName | The name of the Kubernetes Secret that contains the ring key, which encrypts the communication between Habitat supervisors. | string | false |
 | bind | When one service connects to another forming a producer/consumer relationship. Able to specify multiple binds. | [][Bind](#bind) | false |
+| env | A list of environment variables | [][EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#envvar-v1-core) | false
 
 ## Bind
 

--- a/examples/env-vars/README.md
+++ b/examples/env-vars/README.md
@@ -9,7 +9,9 @@ After the Habitat operator is up and running, execute the following command from
     kubectl create -f examples/env-vars/habitat.yml
 
 By default, Redis listens on port 6379, but we change this to 6999 by passing
-the `HAB_REDIS` environment variable to the supervisor.
+the `HAB_REDIS` environment variable to the supervisor (the supervisor
+automatically loads environment variables named `HAB_PACKAGENAME`, as explained
+[here](https://www.habitat.sh/docs/using-habitat/#config-updates)).
 
 When you inspect the logs of the pod that was just created (with `kubectl logs
 $podname`) you should see something like:

--- a/examples/env-vars/README.md
+++ b/examples/env-vars/README.md
@@ -1,0 +1,23 @@
+# Configuration via environment variables
+
+This example demonstrates how environment variables can be used for service configuration.
+
+## Workflow
+
+After the Habitat operator is up and running, execute the following command from the root of this repository:
+
+    kubectl create -f examples/env-vars/habitat.yml
+
+By default, Redis listens on port 6379, but we change this to 6999 by passing
+the `HAB_REDIS` environment variable to the supervisor.
+
+When you inspect the logs of the pod that was just created (with `kubectl logs
+$podname`) you should see something like:
+
+    redis.foobar(O): 42:M 07 Feb 15:34:08.765 * The server is now ready to accept connections on port 6999
+
+## Environment Variables
+
+You can use the full range of options defined by the Downward API. For an
+overview, please refer to [this
+guide](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/).

--- a/examples/env-vars/README.md
+++ b/examples/env-vars/README.md
@@ -1,6 +1,6 @@
 # Configuration via environment variables
 
-This example demonstrates how environment variables can be used for service configuration.
+This example demonstrates how environment variables can be used for initial service configuration.
 
 ## Workflow
 

--- a/examples/env-vars/habitat.yml
+++ b/examples/env-vars/habitat.yml
@@ -1,0 +1,16 @@
+apiVersion: habitat.sh/v1beta1
+kind: Habitat
+metadata:
+  name: example-env-vars-habitat
+spec:
+  # the core/redis habitat service packaged as a Docker image
+  image: kinvolk/redis-hab
+  count: 1
+  env:
+    - name: HAB_REDIS
+      value: '{ "port": "6999" }'
+  service:
+    name: redis
+    topology: standalone
+    # if not present, defaults to "default"
+    group: foobar

--- a/pkg/apis/habitat/v1beta1/types.go
+++ b/pkg/apis/habitat/v1beta1/types.go
@@ -50,7 +50,7 @@ type HabitatSpec struct {
 	// Env is a list of environment variables.
 	// The EnvVar type is documented at https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#envvar-v1-core.
 	// Optional.
-	Env []corev1.EnvVar `json:"env"`
+	Env []corev1.EnvVar `json:"env,omitempty"`
 }
 
 type HabitatStatus struct {

--- a/pkg/apis/habitat/v1beta1/types.go
+++ b/pkg/apis/habitat/v1beta1/types.go
@@ -15,6 +15,7 @@
 package v1beta1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -46,6 +47,10 @@ type HabitatSpec struct {
 	// Image is the Docker image of the Habitat Service.
 	Image   string  `json:"image"`
 	Service Service `json:"service"`
+	// Env is a list of environment variables.
+	// The EnvVar type is documented at https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#envvar-v1-core.
+	// Optional.
+	Env []corev1.EnvVar `json:"env"`
 }
 
 type HabitatStatus struct {

--- a/pkg/apis/habitat/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/habitat/v1beta1/zz_generated.deepcopy.go
@@ -19,6 +19,7 @@
 package v1beta1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -105,6 +106,13 @@ func (in *HabitatList) DeepCopyObject() runtime.Object {
 func (in *HabitatSpec) DeepCopyInto(out *HabitatSpec) {
 	*out = *in
 	in.Service.DeepCopyInto(&out.Service)
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -639,6 +639,7 @@ func (hc *HabitatController) newDeployment(h *habv1beta1.Habitat) (*appsv1beta1.
 									ReadOnly:  true,
 								},
 							},
+							Env: h.Spec.Env,
 						},
 					},
 					// Define the volume for the ConfigMap.


### PR DESCRIPTION
Adds an Env key to the Habitat.Spec type, which allows users to pass
environment variables to the container.

See #181.