### PR TITLE
Use regex to find all the YAML files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,16 @@ clean-test:
 	kubectl delete clusterrole habitat-operator
 
 update-version:
-	find examples helm -name "*.yml" -o -name "*.yaml" -type f \
+	find examples -name "*.yml" -type f \
 		-exec sed -i.bak \
 		-e "s/habitat-operator:.*/habitat-operator:v$$(cat VERSION)/g" \
+		'{}' \;
+	find helm -name "*.yaml" -type f \
+		-exec sed -i.bak \
 		-e "s/tag:.*/tag: v$$(cat VERSION)/g" \
 		-e "s/version:.*/version: $$(cat VERSION)/g" \
 		'{}' \;
-	find examples helm -name "*.yml.bak" -o -name "*.yaml.bak" -type f \
+	find examples helm -regex '.*\.ya?ml$$.bak' -type f \
 		-exec rm '{}' \;
 
 .PHONY: build test linux image e2e clean-test update-version

--- a/examples/crd.yml
+++ b/examples/crd.yml
@@ -7,7 +7,7 @@ spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: habitat.sh
   # version name to use for REST API: /apis/<group>/<version>
-  version: v1
+  version: v1beta1
   # either Namespaced or Cluster
   scope: Namespaced
   names:

--- a/examples/habitat-operator-deployment.yml
+++ b/examples/habitat-operator-deployment.yml
@@ -11,4 +11,4 @@ spec:
     spec:
       containers:
       - name: habitat-operator
-        image: kinvolk/habitat-operator:v0.4.0
+        image: kinvolk/habitat-operator:v0.5.0

--- a/examples/rbac/habitat-operator.yml
+++ b/examples/rbac/habitat-operator.yml
@@ -11,5 +11,5 @@ spec:
     spec:
       containers:
       - name: habitat-operator
-        image: kinvolk/habitat-operator:v0.4.0
+        image: kinvolk/habitat-operator:v0.5.0
       serviceAccountName: habitat-operator


### PR DESCRIPTION
The rule to update the version string all the YAML files was broken from
4d7775336c4f9da28c752809797f6a42d7bd0942, where we tried to use the '-o'
option of `find` command replace version string in both '*.yaml' and
'*.yml' files. Turns out, that doesn't work for some reason.

So let's just use a regular expression with `find` to keep things simpler
and make the rule work again.