### PR TITLE
Update the supported Habitat version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For a more detailed description of the Habitat operator API have a look at the [
 
 ## Prerequisites
 
-- Habitat `>= 0.36.0`
+- Habitat `>= 0.52.0`
 - Kubernetes cluster with version `1.7.x`, `1.8.x` or `1.9.x`.
 
 ## Installing


### PR DESCRIPTION
The oldest version of Habitat that operator can use is 0.39, because
this is the first version that has the alternative path for
user.toml. But Habitat 0.52 is the first version that watches for
changes in user.toml if it is placed in the alternative path.

So for simplicity, let's just say we support Habitat version from 0.52
onwards.