### PR TITLE
[WIP] Add PersistentVolume support to Habitat type

### DIFF
--- a/examples/persistence/habitat.yml
+++ b/examples/persistence/habitat.yml
@@ -1,0 +1,33 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: example-persistence
+  labels:
+    habitat: "true"
+spec:
+  capacity:
+    storage: 5Gi
+  # storageClassName: example-storage
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/k8spv
+---
+apiVersion: habitat.sh/v1beta1
+kind: Habitat
+metadata:
+  name: example-persistent-habitat
+spec:
+  # the core/redis habitat service packaged as a Docker image
+  image: kinvolk/redis-hab
+  count: 1
+  persistence:
+    size: 1Gi
+    # if not present, defaults to ""
+    # storageClassName: example-storage
+    mountPath: /tmp/yeah
+  service:
+    name: redis
+    topology: standalone
+    # if not present, defaults to "default"
+    group: foobar

--- a/pkg/apis/habitat/v1beta1/types.go
+++ b/pkg/apis/habitat/v1beta1/types.go
@@ -51,6 +51,13 @@ type HabitatSpec struct {
 	// The EnvVar type is documented at https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#envvar-v1-core.
 	// Optional.
 	Env []corev1.EnvVar `json:"env,omitempty"`
+	// Optional.
+	Persistence Persistence `json:"persistence,omitempty"`
+}
+
+type Persistence struct {
+	Enabled bool `json:"enabled"`
+	Size string `json:"size"`
 }
 
 type HabitatStatus struct {

--- a/pkg/apis/habitat/v1beta1/types.go
+++ b/pkg/apis/habitat/v1beta1/types.go
@@ -58,6 +58,7 @@ type HabitatSpec struct {
 type Persistence struct {
 	Enabled bool `json:"enabled"`
 	Size string `json:"size"`
+	MountPath string `json:"mountPath"`
 }
 
 type HabitatStatus struct {

--- a/pkg/apis/habitat/v1beta1/types.go
+++ b/pkg/apis/habitat/v1beta1/types.go
@@ -52,12 +52,11 @@ type HabitatSpec struct {
 	// Optional.
 	Env []corev1.EnvVar `json:"env,omitempty"`
 	// Optional.
-	Persistence Persistence `json:"persistence,omitempty"`
+	Persistence *Persistence `json:"persistence,omitempty"`
 }
 
 type Persistence struct {
-	Enabled bool `json:"enabled"`
-	Size string `json:"size"`
+	Size      string `json:"size"`
 	MountPath string `json:"mountPath"`
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -869,6 +869,10 @@ func (hc *HabitatController) conform(key string) error {
 
 	level.Debug(hc.logger).Log("msg", "validated object")
 
+	if err := hc.handlePVC(h); err != nil {
+		return err
+	}
+
 	deployment, err := hc.newDeployment(h)
 	if err != nil {
 		return err
@@ -889,10 +893,6 @@ func (hc *HabitatController) conform(key string) error {
 		level.Debug(hc.logger).Log("msg", "deployment already existed", "name", deployment.Name)
 	} else {
 		level.Info(hc.logger).Log("msg", "created deployment", "name", deployment.Name)
-	}
-
-	if err := hc.handlePVC(h); err != nil {
-		return err
 	}
 
 	// Handle creation/updating of peer IP ConfigMap.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -550,8 +550,8 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 }
 
 func (hc *HabitatController) handlePVC(h *habv1beta1.Habitat) error {
-	// Create PVC if the flag is enabled.
-	if h.Spec.Persistence.Enabled {
+	// Create PVC if the flag is present.
+	if h.Spec.Persistence != nil {
 		q, err := resource.ParseQuantity(h.Spec.Persistence.Size)
 		if err != nil {
 			return err
@@ -744,8 +744,8 @@ func (hc *HabitatController) newDeployment(h *habv1beta1.Habitat) (*appsv1beta1.
 		base.Spec.Template.Spec.Volumes = append(base.Spec.Template.Spec.Volumes, *secretVolume)
 	}
 
-	// Mount Persistent Volume, if requesed.
-	if h.Spec.Persistence.Enabled {
+	// Mount Persistent Volume, if requested.
+	if h.Spec.Persistence != nil {
 		v := &apiv1.Volume{
 			Name: persistentVolumeName,
 			VolumeSource: apiv1.VolumeSource{


### PR DESCRIPTION
This PR adds a `Persistence` key to the Habitat type, which allows users to setup persistent storage.

## TODO

- [x] Mounting a `PersistentVolume` in each `Pod`.
- [ ] Validate `Size` field, so that the Habitat object creation fails if it's invalid. Right now, the Habitat gets created, while the Deployment fails. Either here or as part of #185.
- [ ] React on PV/PVC updates/deletions/creations
  * is this an aspect where a `StatefulSet` would require less work?
    * No, we would still have to tie the Habitat to the PV.
- [ ] Figure out if we want to support changing the size of the PV
- [x] Figure out if we want to add support for custom `StorageClass`es
  * The downside is that the user can get overwhelmed
  * The upside is that it's the precondition for dynamic provisioning
- [x] Figure out if `Spec.Persistence.Enabled` is a good idea. Normally, the field presence is enough to signal intent: the presence of  `Spec.Persistence` would mean that the user wants it.
- [x] Figure out which storage plugin we can/should use
  * `HostPath` provides no data replication on multi-node clusters
- [x] Add README

Closes #181.
Ref https://github.com/kinvolk/habitat-operator/pull/195.