### PR TITLE
Improvements to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 install: true
 
 go:
-  - 1.8.x
+  - stable
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 # This moves Kubernetes specific config files.
 env:
 - CHANGE_MINIKUBE_NONE_USER=true
-- K8S_VERSION=v1.8.0
+- K8S_VERSION=v1.9.0
 
 # Skip installation of dependencies since they are already in vendor.
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ sudo: required
 
 # This moves Kubernetes specific config files.
 env:
-- CHANGE_MINIKUBE_NONE_USER=true
-- K8S_VERSION=v1.9.0
+  global:
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - K8S_VERSION=v1.9.0
 
 # Skip installation of dependencies since they are already in vendor.
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: required
 # This moves Kubernetes specific config files.
 env:
 - CHANGE_MINIKUBE_NONE_USER=true
+- K8S_VERSION=v1.8.0
 
 # Skip installation of dependencies since they are already in vendor.
 install: true
@@ -17,10 +18,10 @@ git:
 
 before_script:
 # Download kubectl, which is a requirement for using minikube.
-- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 # Download minikube.
 - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-- sudo minikube start --vm-driver=none --kubernetes-version=v1.8.0 --extra-config=apiserver.Authorization.Mode=RBAC
+- sudo minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC
 # Fix the kubectl context, as it's often stale.
 - minikube update-context
 # Wait for Kubernetes to be up and ready.


### PR DESCRIPTION
* Stable go
* Extract k8s version to variable, to easily keep `kubectl` and minikube in sync