### PR TITLE
Replace kinvolk with habitat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
 
 script:
 - make test
-- make TESTIMAGE=kinvolk/habitat-operator:testing e2e
+- make TESTIMAGE=habitat-sh/habitat-operator:testing e2e
 
 after_failure:
 - kubectl logs -lhabitat=true --tail=100

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Please make pull requests against the `master` branch.
 
 1. Start a new feature branch
 1. Make the desired changes to the code base. Please read the
-   [contributing section](https://github.com/kinvolk/habitat-operator/#contributing) of the README before making any
+   [contributing section](https://github.com/habitat-sh/habitat-operator/#contributing) of the README before making any
    changes.
 1. Sign and commit your change(s)
 1. Push your feature branch to GitHub, and create a Pull Request

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 HUB :=
-REPO := kinvolk
+REPO := habitat-sh
 IMAGE := $(if $(HUB),$(HUB)/)$(REPO)/habitat-operator
 TAG := $(shell git describe --tags --always)
 TESTIMAGE :=

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ TAG := $(shell git describe --tags --always)
 TESTIMAGE :=
 
 build:
-	go build -i github.com/kinvolk/habitat-operator/cmd/habitat-operator
+	go build -i github.com/$(REPO)/habitat-operator/cmd/habitat-operator
 
 linux:
 	# Compile statically linked binary for linux.
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s" -o habitat-operator github.com/kinvolk/habitat-operator/cmd/habitat-operator
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s" -o habitat-operator github.com/$(REPO)/habitat-operator/cmd/habitat-operator
 
 image: linux
 	docker build -t "$(IMAGE):$(TAG)" .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/kinvolk/habitat-operator.svg?branch=master)](https://travis-ci.org/kinvolk/habitat-operator) 
-[![Go Report Card](https://goreportcard.com/badge/github.com/kinvolk/habitat-operator)](https://goreportcard.com/report/github.com/kinvolk/habitat-operator)
+[![Build Status](https://travis-ci.org/habitat-sh/habitat-operator.svg?branch=master)](https://travis-ci.org/habitat-sh/habitat-operator) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/habitat-sh/habitat-operator)](https://goreportcard.com/report/github.com/habitat-sh/habitat-operator)
 
 # habitat-operator
 
@@ -11,7 +11,7 @@ The Habitat operator is a Kubernetes controller designed to solve running and au
 
 To learn more about Habitat, please visit the [Habitat website](https://www.habitat.sh/).
 
-For a more detailed description of the Habitat operator API have a look at the [API documentation](https://github.com/kinvolk/habitat-operator/blob/master/docs/api.md).
+For a more detailed description of the Habitat operator API have a look at the [API documentation](https://github.com/habitat-sh/habitat-operator/blob/master/docs/api.md).
 
 ## Prerequisites
 
@@ -20,13 +20,13 @@ For a more detailed description of the Habitat operator API have a look at the [
 
 ## Installing
 
-    go get -u github.com/kinvolk/habitat-operator/cmd/habitat-operator
+    go get -u github.com/habitat-sh/habitat-operator/cmd/habitat-operator
 
 ## Building manually from source directory
 
 First clone the operator:
 
-    git clone https://github.com/kinvolk/habitat-operator.git
+    git clone https://github.com/habitat-sh/habitat-operator.git
     cd habitat-operator
 
 Then build it:
@@ -55,13 +55,13 @@ First build the image:
 
     make image
 
-This will produce a `kinvolk/habitat-operator` image, which can then be deployed to your cluster.
+This will produce a `habitat/habitat-operator` image, which can then be deployed to your cluster.
 
 The name of the generated docker image can be changed with an `IMAGE` variable, for example `make image IMAGE=mycorp/my-habitat-operator`. If the `habitat-operator` name is fine, then a `REPO` variable can be used like `make image REPO=mycorp` to generate the `mycorp/habitat-operator` image. Use the `TAG` variable to change the tag to something else (the default value is taken from `git describe --tags --always`) and a `HUB` variable to avoid using the default docker hub.
 
 #### Using release image
 
-Habitat operator images are located [here](https://hub.docker.com/r/kinvolk/habitat-operator/), they are tagged with the release version.
+Habitat operator images are located [here](https://hub.docker.com/r/habitat-sh/habitat-operator/), they are tagged with the release version.
 
 #### Deploying Habitat operator
 
@@ -86,7 +86,7 @@ To create an example service run:
     kubectl create -f examples/standalone/habitat.yml
 
 This will create a single-pod deployment of an `nginx` Habitat service.
-More examples are located in the [example directory](https://github.com/kinvolk/habitat-operator/tree/master/examples/).
+More examples are located in the [example directory](https://github.com/habitat-sh/habitat-operator/tree/master/examples/).
 
 ## Contributing
 

--- a/cmd/habitat-operator/main.go
+++ b/cmd/habitat-operator/main.go
@@ -29,8 +29,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	habclient "github.com/kinvolk/habitat-operator/pkg/client"
-	habcontroller "github.com/kinvolk/habitat-operator/pkg/controller"
+	habclient "github.com/habitat-sh/habitat-operator/pkg/client"
+	habcontroller "github.com/habitat-sh/habitat-operator/pkg/controller"
 )
 
 type Config struct {

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # API v1beta1
 
-The following is a description of the Habitat operator API. To see manifest example files, have a look at the [examples directory](https://github.com/kinvolk/habitat-operator/tree/master/examples).
+The following is a description of the Habitat operator API. To see manifest example files, have a look at the [examples directory](https://github.com/habitat-sh/habitat-operator/tree/master/examples).
 
 ## Habitat
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # Examples
 
-To see all avaliable fields have a look at the [API docs](https://github.com/kinvolk/habitat-operator/blob/master/docs/api.md).
+To see all avaliable fields have a look at the [API docs](https://github.com/habitat-sh/habitat-operator/blob/master/docs/api.md).
 
-To run any of these examples, the Habitat operator must be up and running. To achieve that just follow this [usage documention](https://github.com/kinvolk/habitat-operator#usage).
+To run any of these examples, the Habitat operator must be up and running. To achieve that just follow this [usage documention](https://github.com/habitat-sh/habitat-operator#usage).
 
 Note: Each example has their own documentation.

--- a/examples/bind-config/habitat.yml
+++ b/examples/bind-config/habitat.yml
@@ -14,7 +14,7 @@ kind: Habitat
 metadata:
   name: example-bind-configured-db
 spec:
-  image: kinvolk/redis-hab
+  image: habitat/redis-hab
   count: 1
   service:
     name: redis
@@ -28,7 +28,7 @@ kind: Habitat
 metadata:
   name: example-bind-configured-web-app
 spec:
-  image: kinvolk/bindgo-hab
+  image: habitat/bindgo-hab
   count: 1
   service:
     name: hab-server-go

--- a/examples/bind/habitat.yml
+++ b/examples/bind/habitat.yml
@@ -3,7 +3,7 @@ kind: Habitat
 metadata:
   name: db
 spec:
-  image: kinvolk/redis-hab
+  image: habitat/redis-hab
   count: 1
   service:
     name: redis
@@ -14,7 +14,7 @@ kind: Habitat
 metadata:
   name: web-app
 spec:
-  image: kinvolk/bindgo-hab
+  image: habitat/bindgo-hab
   count: 1
   service:
     name: hab-server-go

--- a/examples/config/habitat.yml
+++ b/examples/config/habitat.yml
@@ -13,7 +13,7 @@ kind: Habitat
 metadata:
   name: example-configured-habitat
 spec:
-  image: kinvolk/redis-hab
+  image: habitat/redis-hab
   count: 1
   service:
     name: db

--- a/examples/encrypted/habitat.yml
+++ b/examples/encrypted/habitat.yml
@@ -17,7 +17,7 @@ metadata:
   name: example-encrypted-habitat
 spec:
   # the core/redis habitat service packaged as a Docker image
-  image: kinvolk/redis-hab
+  image: habitat/redis-hab
   count: 3
   service:
     name: redis

--- a/examples/env-vars/habitat.yml
+++ b/examples/env-vars/habitat.yml
@@ -4,7 +4,7 @@ metadata:
   name: example-env-vars-habitat
 spec:
   # the core/redis habitat service packaged as a Docker image
-  image: kinvolk/redis-hab
+  image: habitat/redis-hab
   count: 1
   env:
     - name: HAB_REDIS

--- a/examples/habitat-operator-deployment.yml
+++ b/examples/habitat-operator-deployment.yml
@@ -11,4 +11,4 @@ spec:
     spec:
       containers:
       - name: habitat-operator
-        image: kinvolk/habitat-operator:v0.5.1
+        image: habitat/habitat-operator:v0.5.1

--- a/examples/leader/habitat.yml
+++ b/examples/leader/habitat.yml
@@ -4,7 +4,7 @@ metadata:
   name: example-leader-follower-habitat
 spec:
   # the core/redis habitat service packaged as a Docker image
-  image: kinvolk/redis-hab
+  image: habitat/redis-hab
   # count must be at least 3 for a leader-follower topology
   count: 3
   service:

--- a/examples/namespaced/habitat.yml
+++ b/examples/namespaced/habitat.yml
@@ -10,7 +10,7 @@ metadata:
   namespace: example-namespace
 spec:
   # the core/redis habitat service packaged as a Docker image
-  image: kinvolk/redis-hab
+  image: habitat/redis-hab
   count: 1
   service:
     name: redis

--- a/examples/rbac/habitat-operator.yml
+++ b/examples/rbac/habitat-operator.yml
@@ -11,5 +11,5 @@ spec:
     spec:
       containers:
       - name: habitat-operator
-        image: kinvolk/habitat-operator:v0.5.1
+        image: habitat/habitat-operator:v0.5.1
       serviceAccountName: habitat-operator

--- a/examples/standalone/habitat.yml
+++ b/examples/standalone/habitat.yml
@@ -4,7 +4,7 @@ metadata:
   name: example-standalone-habitat
 spec:
   # the core/redis habitat service packaged as a Docker image
-  image: kinvolk/redis-hab
+  image: habitat/redis-hab
   count: 1
   service:
     name: redis

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -31,6 +31,6 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-ge
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
 ${CODEGEN_PKG}/generate-groups.sh deepcopy \
-  github.com/kinvolk/habitat-operator/pkg/client github.com/kinvolk/habitat-operator/pkg/apis \
+  github.com/habitat-sh/habitat-operator/pkg/client github.com/habitat-sh/habitat-operator/pkg/apis \
   habitat:v1beta1 \
   --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt

--- a/helm/habitat-operator/Chart.yaml
+++ b/helm/habitat-operator/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     email: zeeshan@kinvolk.io
 name: habitat-operator
 sources:
-  - https://github.com/kinvolk/habitat-operator
+  - https://github.com/habitat-sh/habitat-operator
 version: 0.5.1

--- a/helm/habitat-operator/README.md
+++ b/helm/habitat-operator/README.md
@@ -1,16 +1,16 @@
 # habitat-operator
 
-Installs [habitat-operator](https://github.com/kinvolk/habitat-operator) to manage Habitat services in a Kubernetes cluster.
+Installs [habitat-operator](https://github.com/habitat-sh/habitat-operator) to manage Habitat services in a Kubernetes cluster.
 
 ## Introduction
 
-This chart bootstraps a [habitat-operator](https://github.com/kinvolk/habitat-operator) deployment in a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [habitat-operator](https://github.com/habitat-sh/habitat-operator) deployment in a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
 Note: If you have Kubernetes and Helm installed, skip to [this section](#Installing the Chart).
 
-See [Habitat Operator's README](https://github.com/kinvolk/habitat-operator/blob/master/README.md).
+See [Habitat Operator's README](https://github.com/habitat-sh/habitat-operator/blob/master/README.md).
 
 ### RBAC
 If role-based access control (RBAC) is enabled in your cluster, you may need to give Tiller (the server-side component of Helm) additional permissions. **If RBAC is not enabled, be sure to set `rbacEnable` to `false` when installing the chart.**
@@ -37,7 +37,7 @@ $ helm init --service-account tiller
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm repo add habitat https://kinvolk.github.io/habitat-operator/helm/charts/stable/
+$ helm repo add habitat https://habitat-sh.github.io/habitat-operator/helm/charts/stable/
 $ helm install --name my-release habitat/habitat-operator
 ```
 
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the habitat-operator ch
 
 Parameter | Description | Default
 --- | --- | ---
-`image.repository` | Image | `docker.io/kinvolk/habitat-operator`
+`image.repository` | Image | `docker.io/habitat/habitat-operator`
 `image.tag` | Image tag | The latest release tag (e.g `v0.4.0`)
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `nodeSelector` | Node labels for pod assignment | `{}`
@@ -82,4 +82,4 @@ $ helm install --name my-release habitat/habitat-operator -f values.yaml
 
 ## Hosting
 
-The Helm chart repository is managed on the [`gh-pages` branch](https://github.com/kinvolk/habitat-operator/tree/gh-pages) and instructions for repository management can be found [here](https://github.com/kinvolk/habitat-operator/tree/gh-pages/helm/charts).
+The Helm chart repository is managed on the [`gh-pages` branch](https://github.com/habitat-sh/habitat-operator/tree/gh-pages) and instructions for repository management can be found [here](https://github.com/habitat-sh/habitat-operator/tree/gh-pages/helm/charts).

--- a/helm/habitat-operator/values.yaml
+++ b/helm/habitat-operator/values.yaml
@@ -1,7 +1,7 @@
 ## Habitat-operator image
 ##
 image:
-  repository: docker.io/kinvolk/habitat-operator
+  repository: docker.io/habitat/habitat-operator
   tag: v0.5.1
   pullPolicy: IfNotPresent
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,7 +16,7 @@
 package client
 
 import (
-	habv1beta1 "github.com/kinvolk/habitat-operator/pkg/apis/habitat/v1beta1"
+	habv1beta1 "github.com/habitat-sh/habitat-operator/pkg/apis/habitat/v1beta1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"

--- a/pkg/client/habitat.go
+++ b/pkg/client/habitat.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"time"
 
-	habv1beta1 "github.com/kinvolk/habitat-operator/pkg/apis/habitat/v1beta1"
+	habv1beta1 "github.com/habitat-sh/habitat-operator/pkg/apis/habitat/v1beta1"
 
 	apiv1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	habv1beta1 "github.com/kinvolk/habitat-operator/pkg/apis/habitat/v1beta1"
+	habv1beta1 "github.com/habitat-sh/habitat-operator/pkg/apis/habitat/v1beta1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -17,7 +17,7 @@ package controller
 import (
 	"fmt"
 
-	habv1beta1 "github.com/kinvolk/habitat-operator/pkg/apis/habitat/v1beta1"
+	habv1beta1 "github.com/habitat-sh/habitat-operator/pkg/apis/habitat/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/release.md
+++ b/release.md
@@ -20,12 +20,12 @@ After the above mentioned PR was merged, switch to the updated master branch. Ta
 
 ## Generate release image
 
-In the root directory of the repository generate the Docker image and push it to the Kinvolk repo on Docker hub:
+In the root directory of the repository generate the Docker image and push it to Docker hub:
 
     make image
-    docker push kinvolk/habitat-operator:vx.y.z
-    docker tag kinvolk/habitat-operator:vx.y.z kinvolk/habitat-operator:latest
-    docker push kinvolk/habitat-operator:latest
+    docker push habitat/habitat-operator:vx.y.z
+    docker tag habitat/habitat-operator:vx.y.z habitat-sh/habitat-operator:latest
+    docker push habitat/habitat-operator:latest
 
 ## Generate the Helm chart
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -17,7 +17,7 @@
 package framework
 
 import (
-	habclient "github.com/kinvolk/habitat-operator/pkg/client"
+	habclient "github.com/habitat-sh/habitat-operator/pkg/client"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"time"
 
-	habv1beta1 "github.com/kinvolk/habitat-operator/pkg/apis/habitat/v1beta1"
+	habv1beta1 "github.com/habitat-sh/habitat-operator/pkg/apis/habitat/v1beta1"
 
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/api/core/v1"

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"testing"
 
-	operatorFramework "github.com/kinvolk/habitat-operator/test/e2e/framework"
+	operatorFramework "github.com/habitat-sh/habitat-operator/test/e2e/framework"
 )
 
 var framework *operatorFramework.Framework
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 		code int
 	)
 
-	image := flag.String("image", "", "habitat operator image, 'kinvolk/habitat-operator'")
+	image := flag.String("image", "", "habitat operator image, 'habitat-sh/habitat-operator'")
 	kubeconfig := flag.String("kubeconfig", "", "path to kube config file")
 	externalIP := flag.String("ip", "", "external ip, eg. minikube ip")
 	flag.Parse()

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
-	habv1beta1 "github.com/kinvolk/habitat-operator/pkg/apis/habitat/v1beta1"
-	utils "github.com/kinvolk/habitat-operator/test/e2e/framework"
+	habv1beta1 "github.com/habitat-sh/habitat-operator/pkg/apis/habitat/v1beta1"
+	utils "github.com/habitat-sh/habitat-operator/test/e2e/framework"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,7 +30,7 @@ const (
 	defaultWaitTime = 1 * time.Minute
 	configMapName   = "peer-watch-file"
 
-	nodejsImage = "kinvolk/nodejs-hab:test"
+	nodejsImage = "habitat-sh/nodejs-hab:test"
 )
 
 // TestBind tests that the operator correctly created two Habitat Services and bound them together.
@@ -102,7 +102,7 @@ func TestBind(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// This msg is set in the config of the kinvolk/bindgo-hab Go Habitat Service.
+	// This msg is set in the config of the habitat/bindgo-hab Go Habitat Service.
 	expectedMsg := "hello from port: 4444"
 	actualMsg := body
 	// actualMsg can contain whitespace and newlines or different formatting,
@@ -128,7 +128,7 @@ func TestBind(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Update the message set in the config of the kinvolk/bindgo-hab Go Habitat Service.
+	// Update the message set in the config of the habitat/bindgo-hab Go Habitat Service.
 	expectedMsg = fmt.Sprintf("hello from port: %v", 6333)
 	actualMsg = body
 	// actualMsg can contain whitespace and newlines or different formatting,

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -29,8 +29,6 @@ import (
 const (
 	defaultWaitTime = 1 * time.Minute
 	configMapName   = "peer-watch-file"
-
-	nodejsImage = "habitat-sh/nodejs-hab:test"
 )
 
 // TestBind tests that the operator correctly created two Habitat Services and bound them together.

--- a/test/e2e/resources/bind-config/db.yml
+++ b/test/e2e/resources/bind-config/db.yml
@@ -3,7 +3,7 @@ kind: Habitat
 metadata:
   name: test-redis
 spec:
-  image: kinvolk/redis-hab
+  image: habitat/redis-hab
   count: 1
   service:
     name: redis

--- a/test/e2e/resources/bind-config/webapp.yml
+++ b/test/e2e/resources/bind-config/webapp.yml
@@ -3,7 +3,7 @@ kind: Habitat
 metadata:
   name: test-go
 spec:
-  image: kinvolk/bindgo-hab
+  image: habitat/bindgo-hab
   count: 1
   service:
     name: hab-server-go

--- a/test/e2e/resources/operator/deployment.yml
+++ b/test/e2e/resources/operator/deployment.yml
@@ -11,5 +11,5 @@ spec:
     spec:
       containers:
       - name: habitat-operator
-        image: kinvolk/habitat-operator:v0.3.0
+        image: habitat/habitat-operator:v0.3.0
       serviceAccountName: habitat-operator

--- a/test/e2e/resources/standalone/habitat.yml
+++ b/test/e2e/resources/standalone/habitat.yml
@@ -3,7 +3,7 @@ kind: Habitat
 metadata:
   name: standalone-test-123
 spec:
-  image: kinvolk/nginx-hab
+  image: habitat/nginx-hab
   count: 1
   service:
     name: nginx


### PR DESCRIPTION
In some place with "habitat-sh" (for code), in others with "habitat" (for Docker images).

I also pushed the images to the [habitat org](https://hub.docker.com/r/habitat).